### PR TITLE
[merge/ design_회원가입레이아웃_#8] fix: AuthLayout헤더추가 #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.5",
+    "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.6",
     "zustand": "^5.0.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,18 @@ import { Route, Routes } from "react-router";
 import Main from "./pages/Main";
 import SignIn from "./pages/SignIn";
 import SignUp from "./pages/SignUp";
+import AuthLayout from "./layouts/AuthLayout";
+import SignUpCompanyInfo from "./pages/SignUpCompanyInfo";
 
 const App = () => {
   return (
     <Routes>
       <Route path="/" element={<Main />} />
-      <Route path="signIn" element={<SignIn />} />
-      <Route path="signUp" element={<SignUp />} />
+      <Route element={<AuthLayout />}>
+        <Route path="signIn" element={<SignIn />} />
+        <Route path="signUp" element={<SignUp />} />
+        <Route path="signUpCompanyInfo" element={<SignUpCompanyInfo />} />
+      </Route>
     </Routes>
   );
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,17 +1,27 @@
 import { useNavigate } from "react-router";
+import { twMerge } from "tailwind-merge";
 
 interface ButtonProps {
   text: string;
+  size: "md" | "lg";
   to?: string;
+  className?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const Button = ({ text, to, onClick }: ButtonProps) => {
+const Button = ({ text, to, size, className, onClick }: ButtonProps) => {
   const navigate = useNavigate();
+  const BASE_STYLE = "flex justify-center items-center bg-[#A1A1A1] font-bold";
+
+  const SIZE_STYLE = {
+    lg: "w-[320px] h-[39px] font-bold",
+    md: "w-[89px] h-[29px] font-bold",
+  }[size];
+
   return (
     <>
       <button
-        className="flex justify-center items-center w-[320px] h-[39px] bg-[#A1A1A1] font-bold"
+        className={twMerge(BASE_STYLE, SIZE_STYLE, className)}
         onClick={(e) => (to ? navigate(to) : onClick && onClick(e))}
       >
         {text}

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from "react-router";
+
+const AuthLayout = () => {
+  return (
+    <>
+      <div>헤더 자리</div>
+      <section className="flex justify-center items-center h-screen">
+        <Outlet />
+      </section>
+    </>
+  );
+};
+
+export default AuthLayout;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -2,17 +2,15 @@ import Button from "../components/common/Button";
 
 const SignIn = () => {
   return (
-    <div className="flex justify-center items-center h-screen">
-      <div className="w-[520px] h-[440px] bg-[#D6D6D6] p-[100px]">
-        <div className="pb-[">
-          <div className="flex flex-col gap-[20px] pb-[40px] border-b-[1px]">
-            <Button text="카카오 계정으로 로그인" />
-            <Button text="Google 계정으로 로그인" />
-          </div>
-          <div className="flex flex-col pt-[40px] gap-[5px]">
-            <span className="text-sm text-center">아직 회원이 아니신가요?</span>
-            <Button text="회원가입하러 가기" to="/signUp" />
-          </div>
+    <div className="w-[520px] h-[440px] bg-[#D6D6D6] p-[100px]">
+      <div>
+        <div className="flex flex-col gap-[20px] pb-[40px] border-b-[1px]">
+          <Button text="카카오 계정으로 로그인" size="lg" />
+          <Button text="Google 계정으로 로그인" size="lg" />
+        </div>
+        <div className="flex flex-col pt-[40px] gap-[5px]">
+          <span className="text-sm text-center">아직 회원이 아니신가요?</span>
+          <Button text="회원가입하러 가기" to="/signUp" size="lg" />
         </div>
       </div>
     </div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,16 @@
+import Button from "../components/common/Button";
+
 const SignUp = () => {
-  return <div>SignUp</div>;
+  return (
+    <div className="w-[520px] h-[298px] bg-[#D6D6D6] p-[100px]">
+      <div>
+        <div className="flex flex-col gap-[20px]">
+          <Button text="카카오 계정으로 가입하기" size="lg" />
+          <Button text="Google 계정으로 가입하기" size="lg" />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default SignUp;

--- a/src/pages/SignUpCompanyInfo.tsx
+++ b/src/pages/SignUpCompanyInfo.tsx
@@ -1,0 +1,41 @@
+import Button from "../components/common/Button";
+
+const SignUpCompanyInfo = () => {
+  return (
+    <div className="flex justify-center items-center w-[450px] h-[385px] bg-[#D6D6D6] px-[50px] py-[100px]">
+      <div className="flex flex-col gap-[20px]">
+        <div className="flex flex-col gap-[10px]">
+          <span className="font-bold">이름</span>
+          <input
+            type="text"
+            value="홍길동"
+            disabled
+            className="w-[250px] h-[33px] pl-[10px] bg-[#9A9A9A] font-bold"
+          />
+        </div>
+        <div className="flex flex-col gap-[10px]">
+          <span className="font-bold">이메일</span>
+          <input
+            type="text"
+            value="hong@gmail.com"
+            disabled
+            className="w-[250px] h-[33px] pl-[10px] bg-[#9A9A9A] font-bold"
+          />
+        </div>
+        <div className="flex flex-col gap-[10px]">
+          <span className="font-bold">소속</span>
+          <input
+            type="text"
+            value="이룸 7팀"
+            className="w-[250px] h-[33px] pl-[10px] bg-[#9A9A9A] font-bold focus:outline-none"
+          />
+        </div>
+        <div className="flex justify-center">
+          <Button text="등록하기" size="md" to="/" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignUpCompanyInfo;


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

1. 회원가입, 회원가입 후 소속 입력 페이지 레이아웃 퍼블리싱했습니다
2. AuthLayout에 헤더 추가했습니다.
3. 헤더에서 로그인, 회원가입 클릭 시 로그인, 회원가입으로 이동하도록 경로 수정했습니다.

## 🔗 관련 이슈

#8

## 📸 스크린샷 (선택)

<img width="1439" alt="스크린샷 2025-02-13 오후 5 48 56" src="https://github.com/user-attachments/assets/631a3027-2368-45fb-b5b6-951dfae4feb1" />
<img width="1439" alt="스크린샷 2025-02-13 오후 5 49 20" src="https://github.com/user-attachments/assets/33ae46fe-7fa9-495c-a17f-76a283ead6c7" />
