### PR TITLE
Feat: 캘린더 임시데이터 삽입, 드래그 기능, 커스텀/ 메인페이지 디자인 수정 #25

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.66.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.7.9",
+    "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.5",

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -1,0 +1,61 @@
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import koLocale from "@fullcalendar/core/locales/ko";
+import interactionPlugin from "@fullcalendar/interaction";
+import "../../styles/Calandar.css";
+
+const PROJECT_BUTTON = {
+  text: "프로젝트",
+  click: (info: any) => console.log(info),
+};
+
+const TASK_BUTTON = {
+  text: "개인업무",
+  click: (info: any) => console.log(info),
+};
+const Calendar = () => {
+  // 캘린더 상단 커스텀 버튼(프로젝트, 개인업무)
+
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, interactionPlugin]}
+      customButtons={{ project: PROJECT_BUTTON, task: TASK_BUTTON }}
+      initialView="dayGridMonth"
+      height="100%"
+      viewHeight="100%"
+      headerToolbar={{
+        left: "prev title next",
+        center: "",
+        right: "project task",
+      }}
+      // 한국어
+      locale={koLocale}
+      // 데이터
+      events={[
+        {
+          title: "event 1",
+          date: "2025-02-14",
+          color: "#CAD2CB",
+          start: "2025-02-14",
+          end: "2025-02-23",
+        },
+        {
+          title: "event 2",
+          date: "2025-02-20",
+          color: "#FEE500",
+          textColor: "black",
+        },
+      ]}
+      // 데이터 클릭이벤트
+      eventClick={() => {
+        // alert("Event:" + info.event.title);
+      }}
+      // 드래그
+      editable={true}
+      droppable={true}
+      eventDrop={(info) => console.log(info)}
+    />
+  );
+};
+
+export default Calendar;

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -38,6 +38,7 @@ const Calendar = () => {
           color: "#CAD2CB",
           start: "2025-02-14",
           end: "2025-02-23",
+          textColor: "black",
         },
         {
           title: "event 2",

--- a/src/components/MainPage/ScheduleBox.tsx
+++ b/src/components/MainPage/ScheduleBox.tsx
@@ -18,27 +18,23 @@ const ScheduleBox = ({
   return (
     <div
       className={twMerge(
-        `font-bold w-full h-[80px] flex justify-around flex-shrink-0
-          items-center px-5 bg-[#a1a1a1] cursor-pointer
-          ${isDeadline && "bg-[#FF7676] text-white"}`
+        `w-full h-[110px] flex flex-col justify-around flex-shrink-0 text-main-green01
+          items-center px-3 pb-2 bg-main-green02 cursor-pointer rounded-[10px]
+          ${isDeadline && "bg-[#FF6854] text-white"}`
       )}
     >
       {/* 마감시간, 남은시간 */}
       <div>
-        <div className="flex items-center gap-2">
-          <p className="text-[12px]">마감시간</p>
+        <div className="flex items-center gap-4 text-[30px] ">
           <p>{endTime}</p>
-        </div>
 
-        <div className="flex items-center gap-2">
-          <p className="text-[12px]">남은시간</p>
-          <p>{remainingTime}</p>
+          <p className="text-[14px]">{remainingTime} 남음</p>
         </div>
       </div>
 
       {/* 업무명, 프로젝트 명 */}
-      <div>
-        <p>{scheduleName}</p>
+      <div className="w-full py-1 px-2 shadow-2xl bg-white/25 rounded-[5px]">
+        <p className="font-bold">{scheduleName}</p>
         <p>{projectName}</p>
       </div>
     </div>

--- a/src/components/MainPage/TodaySchedule.tsx
+++ b/src/components/MainPage/TodaySchedule.tsx
@@ -7,14 +7,14 @@ const TodaySchedule = () => {
 
   return (
     <div
-      className="w-[450px] bg-red-100 px-5 py-10
-      flex flex-col gap-10 items-center"
-      style={{ height: "calc(100vh - 50px)" }}
+      className="w-[450px] px-5 py-10 border border-main-green02 rounded-[10px]
+      flex flex-col gap-10 items-center bg-white"
+      style={{ maxHeight: "calc(100vh - 50px)" }}
     >
       <p className="font-bold text-[26px]">현재 날짜 시간</p>
 
       <div className="w-full flex-1 min-h-0">
-        <div className="overflow-y-auto w-full h-full flex flex-col gap-2 min-h-0">
+        <div className="overflow-y-auto scrollbar-none w-full h-full flex flex-col gap-2 min-h-0">
           {arr.map((_, i) => (
             <ScheduleBox
               key={i}

--- a/src/components/MainPage/TodaySchedule.tsx
+++ b/src/components/MainPage/TodaySchedule.tsx
@@ -1,17 +1,43 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ScheduleBox from "./ScheduleBox";
+import dayjs from "dayjs";
+import "dayjs/locale/ko";
 
 const TodaySchedule = () => {
+  dayjs.locale("ko");
+  // 현재 날짜
+  const now = dayjs();
+  const year = now.format("YY"); // '24' 형식
+  const month = now.format("MM"); // '02' 형식
+  const nowDate = now.format("DD"); // '16' 형식
+  const day = now.format("ddd"); // 요일 (0: 일요일 ~ 6: 토요일)
+
+  // 현재 시간
+  // 1초마다 재랜더링 이슈
+  const [time, setTime] = useState(dayjs().format("HH:mm:ss"));
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTime(dayjs().format("HH:mm:ss"));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
   // 임시 배열입니다
   const [arr, setArr] = useState(Array.from({ length: 20 }, (_, i) => i));
 
   return (
     <div
-      className="w-[450px] px-5 py-10 border border-main-green02 rounded-[10px]
+      className="w-[400px] px-5 py-10 border border-main-green02 rounded-[10px]
       flex flex-col gap-10 items-center bg-white"
       style={{ maxHeight: "calc(100vh - 50px)" }}
     >
-      <p className="font-bold text-[26px]">현재 날짜 시간</p>
+      <div className="flex flex-col items-center">
+        <p className="font-medium">
+          {year}년 {month}월 {nowDate}일 ({day})
+        </p>
+        <p className="font-bold text-[26px]">{time}</p>
+      </div>
 
       <div className="w-full flex-1 min-h-0">
         <div className="overflow-y-auto scrollbar-none w-full h-full flex flex-col gap-2 min-h-0">
@@ -22,7 +48,7 @@ const TodaySchedule = () => {
               remainingTime="40분"
               scheduleName="퍼블리싱"
               projectName="이룸 프로젝트"
-              isDeadline={i < 4}
+              isDeadline={i < 4} // 임시
             />
           ))}
         </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,6 +4,7 @@ import TodaySchedule from "../components/MainPage/TodaySchedule";
 import { useOutletContext } from "react-router";
 import { twMerge } from "tailwind-merge";
 import koLocale from "@fullcalendar/core/locales/ko";
+import interactionPlugin from "@fullcalendar/interaction";
 
 const MainPage = () => {
   const sidebarToggle = useOutletContext();
@@ -24,15 +25,17 @@ const MainPage = () => {
           </ul>
         </div>
         <FullCalendar
-          plugins={[dayGridPlugin]}
+          plugins={[dayGridPlugin, interactionPlugin]}
           initialView="dayGridMonth"
           height={"calc(100vh - 50px)"}
           headerToolbar={{
-            start: "prev title next", // will normally be on the left. if RTL, will be on the right
+            start: "prev title next",
             center: "",
-            end: "", // will normally be on the right. if RTL, will be on the left
+            end: "",
           }}
+          // 한국어
           locale={koLocale}
+          // 데이터
           events={[
             {
               title: "event 1",
@@ -43,9 +46,14 @@ const MainPage = () => {
             },
             { title: "event 2", date: "2025-02-20" },
           ]}
+          // 데이터 클릭이벤트
           eventClick={(info) => {
-            alert("Event:" + info.event.title);
+            // alert("Event:" + info.event.title);
           }}
+          // 드래그
+          editable={true}
+          droppable={true}
+          eventDrop={() => alert("ss")}
         />
       </div>
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,6 +3,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import TodaySchedule from "../components/MainPage/TodaySchedule";
 import { useOutletContext } from "react-router";
 import { twMerge } from "tailwind-merge";
+import koLocale from "@fullcalendar/core/locales/ko";
 
 const MainPage = () => {
   const sidebarToggle = useOutletContext();
@@ -26,6 +27,25 @@ const MainPage = () => {
           plugins={[dayGridPlugin]}
           initialView="dayGridMonth"
           height={"calc(100vh - 50px)"}
+          headerToolbar={{
+            start: "prev title next", // will normally be on the left. if RTL, will be on the right
+            center: "",
+            end: "", // will normally be on the right. if RTL, will be on the left
+          }}
+          locale={koLocale}
+          events={[
+            {
+              title: "event 1",
+              date: "2025-02-14",
+              color: "#CAD2CB",
+              start: "2025-02-14",
+              end: "2025-02-23",
+            },
+            { title: "event 2", date: "2025-02-20" },
+          ]}
+          eventClick={(info) => {
+            alert("Event:" + info.event.title);
+          }}
         />
       </div>
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,10 +1,7 @@
-import FullCalendar from "@fullcalendar/react";
-import dayGridPlugin from "@fullcalendar/daygrid";
 import TodaySchedule from "../components/MainPage/TodaySchedule";
 import { useOutletContext } from "react-router";
 import { twMerge } from "tailwind-merge";
-import koLocale from "@fullcalendar/core/locales/ko";
-import interactionPlugin from "@fullcalendar/interaction";
+import Calendar from "../components/MainPage/Calendar";
 
 const MainPage = () => {
   const sidebarToggle = useOutletContext();
@@ -12,49 +9,17 @@ const MainPage = () => {
   return (
     <div
       className={twMerge(
-        `px-5 bg-gray-100 flex gap-2 ${sidebarToggle ? "" : "pl-[130px]"}`
+        `bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0
+        px-5 py-5 flex gap-2 h-[calc(100vh-50px)] ${
+          sidebarToggle ? "" : "pl-[130px]"
+        }`
       )}
-      style={{ height: "calc(100vh - 50px)" }}
     >
       {/* 캘린더 */}
-      <div className="flex-1 px-[60px] flex flex-col gap-2">
-        <div className="flex justify-end">
-          <ul className="flex gap-2 font-bold">
-            <li className="bg-[#a1a1a1] px-3 py-1 cursor-pointer">프로젝트</li>
-            <li className="bg-[#a1a1a1] px-3 py-1 cursor-pointer">개인업무</li>
-          </ul>
+      <div className="flex-1 pl-[50px] pr-[40px] ">
+        <div className="h-[calc(100vh-90px)] border rounded-[10px] border-main-green02 px-5 py-5 bg-white">
+          <Calendar />
         </div>
-        <FullCalendar
-          plugins={[dayGridPlugin, interactionPlugin]}
-          initialView="dayGridMonth"
-          height={"calc(100vh - 50px)"}
-          headerToolbar={{
-            start: "prev title next",
-            center: "",
-            end: "",
-          }}
-          // 한국어
-          locale={koLocale}
-          // 데이터
-          events={[
-            {
-              title: "event 1",
-              date: "2025-02-14",
-              color: "#CAD2CB",
-              start: "2025-02-14",
-              end: "2025-02-23",
-            },
-            { title: "event 2", date: "2025-02-20" },
-          ]}
-          // 데이터 클릭이벤트
-          eventClick={(info) => {
-            // alert("Event:" + info.event.title);
-          }}
-          // 드래그
-          editable={true}
-          droppable={true}
-          eventDrop={() => alert("ss")}
-        />
       </div>
 
       {/* 오늘의 일정 */}

--- a/src/styles/Calandar.css
+++ b/src/styles/Calandar.css
@@ -1,0 +1,54 @@
+.fc-media-screen {
+  /* height: 100% !important; */
+}
+
+.fc-toolbar-chunk {
+  display: flex;
+  align-items: center;
+}
+
+.fc-next-button,
+.fc-prev-button {
+  width: 25px;
+  height: 25px;
+  background-color: white;
+  display: flex !important;
+  justify-content: center;
+  align-items: center;
+  background-color: white !important;
+  border: 1px solid #cad2cb !important;
+}
+
+.fc .fc-button:focus {
+  box-shadow: none !important;
+}
+
+.fc-icon::before {
+  color: #cad2cb !important;
+}
+
+/* 커스텀 프로젝트 버튼 */
+.fc-project-button {
+  width: 70px !important;
+  height: 30px !important;
+  font-size: 14px !important;
+  font-weight: bold !important;
+  background-color: #465448 !important;
+  color: #fff6e9 !important;
+  padding: 0 !important;
+  border: none !important;
+  border-radius: 5px !important;
+}
+
+/* 커스텀 개인업무 버튼 */
+.fc-task-button {
+  width: 70px !important;
+  height: 30px !important;
+  font-size: 14px !important;
+  font-weight: bold !important;
+  background-color: #fff !important;
+  color: #cad2cb !important;
+  padding: 0 !important;
+  border: 1px solid #cad2cb !important;
+  border-radius: 5px !important;
+}

--- a/src/styles/Calandar.css
+++ b/src/styles/Calandar.css
@@ -1,7 +1,3 @@
-.fc-media-screen {
-  /* height: 100% !important; */
-}
-
 .fc-toolbar-chunk {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항
- 라이브러리 설치
1. dayjs 날짜 포맷팅
2. @fullcalendar/interaction 캘린더 드래그 기능 라이브러리


**캘린더 컴포넌트로 분리하였습니다**
캘린더 디자인 커스텀해서 변경했습니다.
캘린더 부분에 데이터 삽입했고 현재 드래그 기능까지 됩니다.

메인페이지 업무일정 부분 피그마에 맞게 수정했습니다.
피그마에서는 분까지 나와있는데 초 단위까지 화면에 보여주고 1초마다 업데이트 되도록 하였습니다

## 🔗 관련 이슈

#25 

## 📸 스크린샷 (선택)
<img width="2556" alt="스크린샷 2025-02-17 오전 10 54 18" src="https://github.com/user-attachments/assets/4a679353-aee2-47d0-adb9-52cad4a29a00" />


