### PR TITLE
Feat: 캘린더 mock데이터 설정, url수정 #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 package-lock.json
+db/*
+db.json

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",
     "dayjs": "^1.11.13",
+    "json-server": "^1.0.0-beta.3",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,23 +17,26 @@ const App = () => {
     <Routes>
       {/* 로그인, 회원가입, 소속등록 페이지 */}
       <Route element={<AuthLayout />}>
-        <Route path="/signIn" element={<SignIn />} />
-        <Route path="/signUp" element={<SignUp />} />
-        <Route path="/signUpCompanyInfo" element={<SignUpCompanyInfo />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/signup" element={<SignUp />} />
+        <Route path="/signup-company-info" element={<SignUpCompanyInfo />} />
       </Route>
 
       {/* 헤더와 사이드바가 있는 페이지 */}
       <Route element={<Layout />}>
         <Route path="/" element={<MainPage />} />
-        <Route path="/projectRoom/:projectId" element={<ProjectRoomDetail />} />
+        <Route
+          path="/project-room/:projectId"
+          element={<ProjectRoomDetail />}
+        />
         <Route path="/admin" element={<Admin />} />
       </Route>
 
       {/* 헤더만 있는 페이지 */}
       <Route element={<HeaderLayout />}>
-        <Route path="/projectRoom" element={<ProjectRoom />} />
-        <Route path="/meetingRoom/:projectId" element={<MeetingRoom />} />
-        <Route path="/myPage" element={<MyPage />} />
+        <Route path="/project-room" element={<ProjectRoom />} />
+        <Route path="/meeting-room/:projectId" element={<MeetingRoom />} />
+        <Route path="/mypage" element={<MyPage />} />
       </Route>
     </Routes>
   );

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "http://localhost:3000",
+});

--- a/src/components/AlamModal/AlarmBox.tsx
+++ b/src/components/AlamModal/AlarmBox.tsx
@@ -38,10 +38,10 @@ const AlarmBox = ({ project, task, theme, css, onRemove }: AlarmBoxProps) => {
   const projectId = ":projectIc";
 
   const THEME_NAVIGATE = {
-    message: `/projectRoom/${projectId}/meetingRoom`,
-    newTask: `/projectRoom/${projectId}`,
-    newProject: `/projectRoom/${projectId}`,
-    endProject: `/projectRoom/${projectId}`,
+    message: `/project-room/${projectId}/meeting-room`,
+    newTask: `/project-room/${projectId}`,
+    newProject: `/project-room/${projectId}`,
+    endProject: `/project-room/${projectId}`,
   }[theme];
 
   const handleClick = () => {

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -3,7 +3,15 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import koLocale from "@fullcalendar/core/locales/ko";
 import interactionPlugin from "@fullcalendar/interaction";
 import "../../styles/Calandar.css";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getProjectList } from "../../utils/api/getProjectList";
+import { useEffect } from "react";
+import { dragChange } from "../../utils/calendar/dragChange";
+import dayjs from "dayjs";
+import { queryClient } from "../../main";
+import { EventDropArg } from "@fullcalendar/core/index.js";
 
+// 캘린더 상단 커스텀 버튼(프로젝트, 개인업무)
 const PROJECT_BUTTON = {
   text: "프로젝트",
   click: (info: any) => console.log(info),
@@ -13,8 +21,28 @@ const TASK_BUTTON = {
   text: "개인업무",
   click: (info: any) => console.log(info),
 };
+
 const Calendar = () => {
-  // 캘린더 상단 커스텀 버튼(프로젝트, 개인업무)
+  const { data, isLoading } = useQuery<ProjectListType[]>({
+    queryKey: ["ProjectList"],
+    queryFn: getProjectList,
+  });
+
+  useEffect(() => {
+    console.log(data, isLoading);
+  }, [data]);
+
+  // 데이터 수정
+  const { mutate } = useMutation({
+    mutationFn: (info: EventDropArg) => dragChange(info),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ProjectList"] });
+    },
+  });
+
+  if (isLoading) {
+    return <div>로딩</div>;
+  }
 
   return (
     <FullCalendar
@@ -31,22 +59,17 @@ const Calendar = () => {
       // 한국어
       locale={koLocale}
       // 데이터
-      events={[
-        {
-          title: "event 1",
-          date: "2025-02-14",
-          color: "#CAD2CB",
-          start: "2025-02-14",
-          end: "2025-02-23",
+      events={data?.map((project: ProjectListType) => {
+        return {
+          id: project.id,
+          title: project.name,
+          data: project.startDate,
+          start: project.startDate,
+          end: project.endDate,
           textColor: "black",
-        },
-        {
-          title: "event 2",
-          date: "2025-02-20",
-          color: "#FEE500",
-          textColor: "black",
-        },
-      ]}
+          color: project.color,
+        };
+      })}
       // 데이터 클릭이벤트
       eventClick={() => {
         // alert("Event:" + info.event.title);
@@ -54,7 +77,14 @@ const Calendar = () => {
       // 드래그
       editable={true}
       droppable={true}
-      eventDrop={(info) => console.log(info)}
+      eventDrop={(info: EventDropArg) => {
+        console.log(dayjs(info.event.start).format("YYYY-MM-DD"));
+        mutate(info);
+      }}
+      // 일정 길이 변경 드래그
+      eventResize={(info: any) => {
+        mutate(info);
+      }}
     />
   );
 };

--- a/src/components/MeetingRoom/MeetingRoomChatBox.tsx
+++ b/src/components/MeetingRoom/MeetingRoomChatBox.tsx
@@ -129,7 +129,7 @@ const MeetingRoomChatBox = ({ css }: { css?: string }) => {
           />
           <Button
             text="미팅룸 나가기"
-            to="/projectRoom"
+            to="/project-room"
             size="sm"
             css="border-header-red bg-header-red/70 text-white text-[14px] font-bold"
           />

--- a/src/components/ProjectRoom/ProjectListBox.tsx
+++ b/src/components/ProjectRoom/ProjectListBox.tsx
@@ -53,7 +53,7 @@ const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
             />
             {filterProject === "진행 중인 프로젝트" && (
               <Link
-                to={`/meetingRoom/${projectId}`}
+                to={`/meeting-room/${projectId}`}
                 className="h-[40px] bg-[#FFFCE2] text-main-green01 flex items-center justify-center
           border border-main-green01 px-[10px] font-bold rounded-sm"
               >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,9 +18,9 @@ const Header = () => {
 
   const { pathname } = useLocation();
   useEffect(() => {
-    if (pathname === "/projectRoom") {
+    if (pathname === "/project-room") {
       setIsOn("Project");
-    } else if (pathname === "/meetingRoom") {
+    } else if (pathname === "/meeting-room") {
       setIsOn("Meeting");
     } else {
       setIsOn("");
@@ -58,7 +58,7 @@ const Header = () => {
               </li>
               <li className="cursor-pointer">
                 {/* 유저정보api 나온 후 url 수정 필요 */}
-                <Link to={`/projectRoom`}>마이프로젝트</Link>
+                <Link to={`/project-room`}>마이프로젝트</Link>
               </li>
               {isAlarmOpen && (
                 <div className="absolute top-[50px] transform -translate-x-1/2">
@@ -66,7 +66,7 @@ const Header = () => {
                 </div>
               )}
               <li>
-                <Link to={"/myPage"}>마이페이지</Link>
+                <Link to={"/mypage"}>마이페이지</Link>
               </li>
               <li
                 onClick={handleLogin}
@@ -78,12 +78,12 @@ const Header = () => {
           ) : (
             <>
               <li>
-                <Link to={"/signIn"} onClick={handleLogin}>
+                <Link to="/signin" onClick={handleLogin}>
                   로그인
                 </Link>
               </li>
               <li>
-                <Link to="/signUp">회원가입</Link>
+                <Link to="/signup">회원가입</Link>
               </li>
             </>
           )}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -47,13 +47,13 @@ const Sidebar = ({ sidebarToggle, setSidebarToggle }: SidebarProps) => {
     else setAdminSideMenu(sidebarTab.get("tab"));
   }, [sidebarTab]);
 
-  if (pathname.startsWith("/projectRoom")) {
+  if (pathname.startsWith("/project-room")) {
     // 프로젝트룸 사이드바
     return (
       <div className="w-[140px] flex-none bg-white min-h-[calc(100vh-50px)]">
         <ul className="flex flex-col items-center gap-6 pt-10 w-[130px]">
           <li>
-            <Link to="/projectRoom" className="flex flex-col items-center">
+            <Link to="/project-room" className="flex flex-col items-center">
               <img src={outProjectIcon} alt="프로젝트 나가기 버튼" />
               <p className="font-bold text-main-green01">My프로젝트</p>
             </Link>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,16 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -30,7 +30,7 @@ const SignIn = () => {
           <span className="text-sm text-center font-semibold">
             아직 회원이 아니신가요?
           </span>
-          <Button text="회원가입" to="/signUp" size="lg" />
+          <Button text="회원가입" to="/signup" size="lg" />
         </div>
       </div>
     </div>

--- a/src/types/projectList.d.ts
+++ b/src/types/projectList.d.ts
@@ -1,0 +1,61 @@
+interface ProjectListType {
+  id: string;
+  creator: {
+    id: number;
+    username: string;
+    email: string;
+  };
+  name: string;
+  color: string;
+  createdAt: string;
+  tag1: string;
+  tag2: string;
+  tag3: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+  chatRoom: {
+    id: number;
+    name: string;
+  };
+  members: [
+    {
+      id: number;
+      user: {
+        id: number;
+        username: string;
+      };
+    },
+    {
+      id: number;
+      user: {
+        id: number;
+        username: string;
+      };
+    },
+    {
+      id: number;
+      user: {
+        id: number;
+        username: string;
+      };
+    }
+  ];
+  tasks: [
+    {
+      id: number;
+      name: string;
+      status: string;
+    },
+    {
+      id: number;
+      name: string;
+      status: string;
+    },
+    {
+      id: number;
+      name: string;
+      status: string;
+    }
+  ];
+}

--- a/src/utils/api/getProjectList.ts
+++ b/src/utils/api/getProjectList.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+export const getProjectList = async () => {
+  try {
+    const { data } = await axios.get("http://localhost:3000/projects");
+    console.log(data);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/utils/calendar/dragChange.ts
+++ b/src/utils/calendar/dragChange.ts
@@ -1,0 +1,22 @@
+import dayjs from "dayjs";
+import { api } from "../../api/api";
+import { EventDropArg } from "@fullcalendar/core/index.js";
+
+// 캘린더 일정 드래그시 호출함수
+export const dragChange = async (info: EventDropArg) => {
+  // 변경된 일정 날짜 포맷팅
+  const startDate = dayjs(info.event.start).format("YYYY-MM-DD");
+  const endDate = dayjs(info.event.end).format("YYYY-MM-DD");
+
+  try {
+    const response = await api.patch(`/projects/${info.event.id}`, {
+      startDate,
+      endDate,
+    });
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+    info.revert();
+  }
+};


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항
1. 웹사이트 url 수정
2. 캘린더 mock데이터 심기
 - 임시 서버 구동을 위해 json-server를 설치하였습니다. (msw를 사용하려다가 이슈가 있어서 변경했습니다)
 - 프로젝트의 리스트는 일단 /projects로 요청하면 받아옵니다. (기존 url ->  /project/list)
 - 로컬 최상단 폴더에 db.json 파일을 생성 후에 mock데이터를 작성하시면 됩니다.
 - axios 인스턴스를 임시로 생성했습니다 baseUrl => localhost:3000
 - 백엔드 측에서 보내주신 Res데이터로 임시로 타입 설정, mock데이터 생성했습니다.

3. 캘린더 데이터 드래그 시 수정
- 드래그 하고 난 후에 서버에 업데이트 요청을 보내는 함수 구현
- 일정 길이 조절할 떄 위와 동일한 함수로 업데이트 요청합니다.

## 🔗 관련 이슈

#42 

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/56b40443-6169-44f2-a4dd-cd2a6babd5ca


