### PR TITLE
feat: 프로젝트 리스트 데이터 적용 #65

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fullcalendar/react": "^6.1.15",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.66.0",
+    "@tanstack/react-query-devtools": "^5.66.7",
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",
     "d3": "^7.9.0",

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -23,14 +23,30 @@ const TASK_BUTTON = {
 };
 
 const Calendar = () => {
-  const { data, isLoading } = useQuery<ProjectListType[]>({
+  const { data: projectListData, isLoading } = useQuery<ProjectListType[]>({
     queryKey: ["ProjectList"],
-    queryFn: getProjectList,
+    queryFn: async () => {
+      const response = await getProjectList();
+      const filterInProgress = response.filter(
+        (project: ProjectListType) => project.status === "IN_PROGRESS"
+      );
+      return filterInProgress.map((project: ProjectListType) => {
+        return {
+          id: project.id,
+          title: project.name,
+          data: project.startDate,
+          start: project.startDate.split("T")[0],
+          end: project.endDate.split("T")[0],
+          textColor: "black",
+          color: "#" + project.color,
+        };
+      });
+    },
   });
 
   useEffect(() => {
-    console.log(data, isLoading);
-  }, [data]);
+    console.log(projectListData, isLoading);
+  }, [projectListData]);
 
   // 데이터 수정
   const { mutate } = useMutation({
@@ -59,17 +75,7 @@ const Calendar = () => {
       // 한국어
       locale={koLocale}
       // 데이터
-      events={data?.map((project: ProjectListType) => {
-        return {
-          id: project.id,
-          title: project.name,
-          data: project.startDate,
-          start: project.startDate,
-          end: project.endDate,
-          textColor: "black",
-          color: project.color,
-        };
-      })}
+      events={projectListData}
       // 데이터 클릭이벤트
       eventClick={() => {
         // alert("Event:" + info.event.title);
@@ -78,7 +84,7 @@ const Calendar = () => {
       editable={true}
       droppable={true}
       eventDrop={(info: EventDropArg) => {
-        console.log(dayjs(info.event.start).format("YYYY-MM-DD"));
+        console.log(dayjs(info.event.start));
         mutate(info);
       }}
       // 일정 길이 변경 드래그

--- a/src/components/ProjectRoom/ProjectListBox.tsx
+++ b/src/components/ProjectRoom/ProjectListBox.tsx
@@ -8,6 +8,8 @@ import EditProjectModal from "../modals/EditProjectModal";
 interface ProjectListBoxProps {
   projectId: number;
   filterProject: string;
+  projectInfo: ProjectListType;
+  idx: number;
 }
 
 // (임시) 프로젝트 박스 카테고리 데이터
@@ -46,10 +48,17 @@ const selectedProjectMember = [
   },
 ];
 
-const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
+const ProjectListBox = ({
+  projectId,
+  filterProject,
+  idx,
+  projectInfo,
+}: ProjectListBoxProps) => {
   const navigate = useNavigate();
   // 프로젝트 생성 모달
   const [isEditProjectModal, setIsEditProjectModal] = useState<boolean>(false);
+
+  const members = projectInfo.memberNames;
 
   return (
     <div
@@ -58,15 +67,18 @@ const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
     >
       <div className="flex gap-5 items-center px-5 font-bold ">
         <p className="text-[50px] font-medium text-main-green02 font-notoTC">
-          10
+          {idx + 1}
         </p>
         {/* 프로젝트 넘버 */}
 
         <div className="flex justify-between items-center w-full px-5">
           {/* 프로젝트 명, 기간 */}
-          <div>
-            <p>프로젝트 명</p>
-            <p>2025.02.03 ~ 2025.03.12</p>
+          <div className="w-[210px]">
+            <p>{projectInfo.name}</p>
+            <p>
+              {projectInfo.startDate.split("T")[0]} ~{" "}
+              {projectInfo.endDate.split("T")[0]}
+            </p>
           </div>
 
           {/* 진행률 */}
@@ -79,14 +91,29 @@ const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
           </div>
 
           {/* 참여인원 */}
-          <div className=" flex items-center gap-4">
+          <div className=" flex items-center gap-4 w-[202px]">
             <p>참여인원</p>
             <div className="flex">
-              <ParticipantIcon css="" />
+              {members.length > 5
+                ? members
+                    .slice(0, 6)
+                    .map((member, idx) => (
+                      <ParticipantIcon
+                        key={idx}
+                        css={idx > 0 ? "ml-[-5px]" : ""}
+                      />
+                    ))
+                : members.map((menber, idx) => (
+                    <ParticipantIcon
+                      key={idx}
+                      css={idx > 0 ? "ml-[-5px]" : ""}
+                    />
+                  ))}
+              {/* <ParticipantIcon css="" />
               <ParticipantIcon css="ml-[-5px] bg-red-100" />
               <ParticipantIcon css="ml-[-5px] bg-blue-100" />
               <ParticipantIcon css="ml-[-5px] bg-green-100" />
-              <ParticipantIcon css="ml-[-5px] bg-pink-100" />
+              <ParticipantIcon css="ml-[-5px] bg-pink-100" /> */}
             </div>
           </div>
 
@@ -102,7 +129,7 @@ const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
             />
             {filterProject === "진행 중인 프로젝트" && (
               <Link
-                to={`/meeting-room/${projectId}`}
+                to={`/meeting-room/${projectInfo.chatRoomId}`}
                 className="h-[40px] bg-[#FFFCE2] text-main-green01 flex items-center justify-center
           border border-main-green01 px-[10px] font-bold rounded-sm"
                 onClick={(e) => e.stopPropagation()}
@@ -125,7 +152,7 @@ const ProjectListBox = ({ projectId, filterProject }: ProjectListBoxProps) => {
           </div>
         </div>
       </div>
-      <ul className="flex gap-2 ml-30 text-main-beige text-[14px]">
+      <ul className="flex gap-2 ml-[90px] text-main-beige text-[14px]">
         <li className="bg-main-green02 px-2 py-1 rounded-[25px] text-main-green01">
           #개발
         </li>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,7 +76,6 @@ const Sidebar = ({ sidebarToggle, setSidebarToggle }: SidebarProps) => {
             return (
               <>
                 <li
-                  key={idx}
                   className="font-bold w-full h-[35px] flex flex-col items-center cursor-pointer
                 "
                 >

--- a/src/components/modals/CreateTaskModal.tsx
+++ b/src/components/modals/CreateTaskModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import Button from "../common/Button";
 import DateTimeSelect from "../CreateModal/DateTimeSelect";
-import WriteProjectName from "../CreateProjectModal/WriteProjectName";
-import SelectMember from "../CreateProjectModal/SelectMember";
+import WriteProjectName from "../EditProjectModal/WriteProjectName";
+import SelectMember from "../EditProjectModal/SelectMember";
 
 interface selectedDateType {
   year: string;

--- a/src/components/modals/UpdateTaskModal.tsx
+++ b/src/components/modals/UpdateTaskModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import Button from "../common/Button";
 import DateTimeSelect from "../CreateModal/DateTimeSelect";
-import SelectMember from "../CreateProjectModal/SelectMember";
-import WriteProjectName from "../CreateProjectModal/WriteProjectName";
+import SelectMember from "../EditProjectModal/SelectMember";
+import WriteProjectName from "../EditProjectModal/WriteProjectName";
 
 interface UpdateTaskModalProps {
   task: {

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@
   --color-main-green03: #ebe9e2;
   --color-logo-green: #2b3e34;
   --color-header-green: #657166;
-  --color-header-header-green-hover: #2b3e34;
+  --color-header-green-hover: #2b3e34;
   --color-red: #ffe3df;
   --color-header-red: #ff6854;
   --color-header-red-hover: #ff1d00;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 export const queryClient = new QueryClient();
 
@@ -11,6 +12,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
         <App />
       </QueryClientProvider>
     </BrowserRouter>

--- a/src/pages/ProjectRoom/ProjectRoom.tsx
+++ b/src/pages/ProjectRoom/ProjectRoom.tsx
@@ -1,10 +1,17 @@
-import { useState } from "react";
-
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import ProjectListBox from "../../components/ProjectRoom/ProjectListBox";
 import Button from "../../components/common/Button";
 import AllProjectOutModal from "../../components/modals/AllProjectOutModal";
 import EditProjectModal from "../../components/modals/EditProjectModal";
+import { useQuery } from "@tanstack/react-query";
+import { getProjectList } from "../../utils/api/getProjectList";
+
+interface ProjectRoomData {
+  completed: ProjectListType[];
+  inProgress: ProjectListType[];
+  beforeStart: ProjectListType[];
+}
 
 const FILTER_PROJECT: (
   | "진행 완료 프로젝트"
@@ -24,8 +31,36 @@ const ProjectRoom = () => {
     "진행 완료 프로젝트" | "진행 중인 프로젝트" | "진행 예정 프로젝트"
   >("진행 중인 프로젝트");
 
-  // 임시 배열
-  const [arr, setArr] = useState(Array.from({ length: 20 }, (_, idx) => idx));
+  // 프로젝트리스트 데이터
+  const { data: projectRoomList, isLoading } = useQuery<ProjectRoomData>({
+    queryKey: ["ProjectRoomList"],
+    queryFn: async () => {
+      const dataList: ProjectListType[] = await getProjectList();
+
+      const inProgressData = dataList.filter(
+        (list) => list.status === "IN_PROGRESS"
+      );
+      const completedData = dataList.filter(
+        (list) => list.status === "COMPLETED"
+      );
+      const beforeStartData = dataList.filter(
+        (list) => list.status === "BEFORE_START"
+      );
+
+      return {
+        completed: completedData,
+        inProgress: inProgressData,
+        beforeStart: beforeStartData,
+      };
+    },
+  });
+
+  useEffect(() => {
+    console.log(projectRoomList, isLoading);
+    if (projectRoomList) {
+      console.log(projectRoomList.completed);
+    }
+  }, [projectRoomList]);
 
   // 전체 프로젝트 나가기 모달
   const [isAllProjectOutModal, setIsAllProjectOutModal] =
@@ -100,13 +135,36 @@ const ProjectRoom = () => {
           className="w-full max-h-[calc(100vh-220px)] flex flex-col gap-4 overflow-y-scroll scrollbar-none
           flex-grow  py-10 rounded-[10px]"
         >
-          {arr.map((_, idx) => (
-            <ProjectListBox
-              key={idx}
-              projectId={idx + 1}
-              filterProject={filterProject}
-            />
-          ))}
+          {filterProject === "진행 예정 프로젝트" &&
+            projectRoomList?.beforeStart.map((project, idx) => (
+              <ProjectListBox
+                key={project.id}
+                idx={idx}
+                projectId={+project.id}
+                filterProject={filterProject}
+                projectInfo={project}
+              />
+            ))}
+          {filterProject === "진행 중인 프로젝트" &&
+            projectRoomList?.inProgress.map((project, idx) => (
+              <ProjectListBox
+                key={project.id}
+                idx={idx}
+                projectId={+project.id}
+                filterProject={filterProject}
+                projectInfo={project}
+              />
+            ))}
+          {filterProject === "진행 완료 프로젝트" &&
+            projectRoomList?.completed.map((project, idx) => (
+              <ProjectListBox
+                key={project.id}
+                idx={idx}
+                projectId={+project.id}
+                filterProject={filterProject}
+                projectInfo={project}
+              />
+            ))}
         </div>
       </div>
 

--- a/src/pages/ProjectRoom/ProjectRoomDetail.tsx
+++ b/src/pages/ProjectRoom/ProjectRoomDetail.tsx
@@ -1,15 +1,29 @@
-import { useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import Button from "../../components/common/Button";
 import TaskList from "../../components/Task/TaskList";
 import { useEffect, useState } from "react";
 import MeetingRoomChatBox from "../../components/MeetingRoom/MeetingRoomChatBox";
 import CreateTaskModal from "../../components/modals/CreateTaskModal";
+import { useQuery } from "@tanstack/react-query";
+import { getProjectDetail } from "../../utils/api/getProjectDetail";
 // import newTaskIcon from "../../assets/icons/newTaskIcon.svg";
 
 const ProjectRoomDetail = () => {
+  const { projectId } = useParams();
   const [searchParams] = useSearchParams();
   const [category, setCategory] = useState(searchParams.get("category"));
   const [isCreateTask, setIsCreateTask] = useState(false);
+
+  console.log(projectId);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["ProjectDetail"],
+    queryFn: () => getProjectDetail(projectId!),
+  });
+
+  useEffect(() => {
+    console.log(data, isLoading);
+  }, [data]);
 
   const handleCreateTaskModal = () => {
     setIsCreateTask((prev) => !prev);

--- a/src/types/projectList.d.ts
+++ b/src/types/projectList.d.ts
@@ -1,10 +1,5 @@
 interface ProjectListType {
   id: string;
-  creator: {
-    id: number;
-    username: string;
-    email: string;
-  };
   name: string;
   color: string;
   createdAt: string;
@@ -14,48 +9,6 @@ interface ProjectListType {
   startDate: string;
   endDate: string;
   status: string;
-  chatRoom: {
-    id: number;
-    name: string;
-  };
-  members: [
-    {
-      id: number;
-      user: {
-        id: number;
-        username: string;
-      };
-    },
-    {
-      id: number;
-      user: {
-        id: number;
-        username: string;
-      };
-    },
-    {
-      id: number;
-      user: {
-        id: number;
-        username: string;
-      };
-    }
-  ];
-  tasks: [
-    {
-      id: number;
-      name: string;
-      status: string;
-    },
-    {
-      id: number;
-      name: string;
-      status: string;
-    },
-    {
-      id: number;
-      name: string;
-      status: string;
-    }
-  ];
+  chatRoomId: number;
+  memberNames: string[];
 }

--- a/src/utils/api/getProjectDetail.ts
+++ b/src/utils/api/getProjectDetail.ts
@@ -1,0 +1,13 @@
+import { api } from "../../api/api";
+
+export const getProjectDetail = async (projectId: string) => {
+  try {
+    const { data } = await api.get("/project-detail");
+
+    // 임시
+    const findProject = data.filter(
+      (project: any) => project.projectId === +projectId
+    );
+    return findProject;
+  } catch (error) {}
+};


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항
- db.json 파일에 mock데이터를 수정해서 다시 설정했습니다.
- 캘린더 부분 로직 수정했습니다.
- 프로젝트룸 페이지에 mock데이터를 받아와서 나열했습니다. 각 탭에 따라 필터링해서 적용했습니다.
- 프로젝트 상세페이지에서 프로젝트 상세데이터를 가져오기까지 구현했습니다.
- create, update task modal에서 파일경로 오류나는거 수정했습니다.

- tanstack query devtools 설치했습니다 npm install 해주세요 !

## 🔗 관련 이슈

#65 

## 📸 스크린샷 (선택)
<img width="2555" alt="스크린샷 2025-02-20 오후 3 47 19" src="https://github.com/user-attachments/assets/9949617e-1b77-4128-87d2-8e59f6196a4b" />
<img width="2557" alt="스크린샷 2025-02-20 오후 3 47 36" src="https://github.com/user-attachments/assets/e47b37b5-9cd3-4227-946c-80746c403847" />


