### PR TITLE
fix: 프로젝트리스트 수정데이터 반영 #89

### DIFF
--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -9,7 +9,7 @@ import { useEffect } from "react";
 import { dragChange } from "../../utils/calendar/dragChange";
 import dayjs from "dayjs";
 import { queryClient } from "../../main";
-import { EventDropArg } from "@fullcalendar/core/index.js";
+import { EventDropArg, EventInput } from "@fullcalendar/core/index.js";
 
 // 캘린더 상단 커스텀 버튼(프로젝트, 개인업무)
 const PROJECT_BUTTON = {
@@ -23,7 +23,8 @@ const TASK_BUTTON = {
 };
 
 const Calendar = () => {
-  const { data: projectListData, isLoading } = useQuery<ProjectListType[]>({
+  // fullcalandar 타입 때문에 EventInput 타입 적용
+  const { data: projectListData, isLoading } = useQuery<EventInput[]>({
     queryKey: ["ProjectList"],
     queryFn: async () => {
       const response = await getProjectList();
@@ -38,8 +39,8 @@ const Calendar = () => {
           data: project.startDate,
           start: project.startDate.split("T")[0],
           end: project.endDate.split("T")[0],
-          textColor: "black",
-          color: "#" + project.color,
+          textColor: "#" + project.colors.text,
+          color: "#" + project.colors.background,
         };
       });
     },

--- a/src/components/ProjectRoom/ProjectListBox.tsx
+++ b/src/components/ProjectRoom/ProjectListBox.tsx
@@ -20,8 +20,10 @@ const ProjectListBox = ({
     dummy.selectedProjectData
   );
 
-  const members = projectInfo.memberNames;
+  const members = projectInfo.members;
 
+  const subcate1 = projectInfo.subCategories1.data;
+  const subcate2 = projectInfo.subCategories2.data;
   return (
     <div
       className="w-full flex gap-[10px] bg-white 
@@ -53,9 +55,9 @@ const ProjectListBox = ({
           <div className="flex flex-col items-center gap-1">
             <div className="w-[200px] flex justify-center gap-[10px] font-bold">
               <p>진행률</p>
-              <p>50.0%</p>
+              <p>{projectInfo.progressRate.toFixed(1)}%</p>
             </div>
-            <ProjectProgressBar />
+            <ProjectProgressBar progress={projectInfo.progressRate} />
           </div>
 
           {/* 참여인원 */}
@@ -67,23 +69,20 @@ const ProjectListBox = ({
               {members.length > 5
                 ? members
                     .slice(0, 6)
-                    .map((_, idx) => (
+                    .map((member, idx) => (
                       <ParticipantIcon
                         key={idx}
                         css={idx > 0 ? "ml-[-5px]" : ""}
+                        imgSrc={member.profile}
                       />
                     ))
-                : members.map((_, idx) => (
+                : members.map((member, idx) => (
                     <ParticipantIcon
                       key={idx}
-                      css={idx > 0 ? "ml-[-5px]" : ""}
+                      css={idx > 0 ? "ml-[-7px]" : ""}
+                      imgSrc={member.profile}
                     />
                   ))}
-              {/* <ParticipantIcon css="" />
-              <ParticipantIcon css="ml-[-5px] bg-red-100" />
-              <ParticipantIcon css="ml-[-5px] bg-blue-100" />
-              <ParticipantIcon css="ml-[-5px] bg-green-100" />
-              <ParticipantIcon css="ml-[-5px] bg-pink-100" /> */}
             </div>
           </div>
 
@@ -120,21 +119,30 @@ const ProjectListBox = ({
               className="h-fit bg-logo-green rounded-[30px] 
             text-main-beige01 leading-none px-[10px] py-[5px] font-bold"
             >
-              #개발
+              # {projectInfo.category}
             </li>
-            <li
-              className="h-fit bg-main-beige01 rounded-[30px]
+            {subcate1.map((cate, idx) => {
+              return (
+                <li
+                  key={idx}
+                  className="h-fit bg-main-beige01 rounded-[30px]
             text-main-green leading-none px-[10px] py-[5px] border border-logo-green"
-            >
-              # TypeScript
-            </li>
-            <li
-              className="h-fit bg-main-green03 rounded-[30px] 
+                >
+                  # {cate}
+                </li>
+              );
+            })}
+            {subcate2.map((cate, idx) => {
+              return (
+                <li
+                  key={idx}
+                  className="h-fit bg-main-green03 rounded-[30px] 
             text-main-green leading-none px-[10px] py-[5px] border border-logo-green "
-            >
-              # React
-            </li>
-            {/* <li className="bg-main-green01 px-2 py-1 rounded-[25px]">#REACT</li> */}
+                >
+                  # {cate}
+                </li>
+              );
+            })}
           </ul>
 
           {/* 미팅룸 버튼 */}

--- a/src/components/ProjectRoom/ProjectProgressBar.tsx
+++ b/src/components/ProjectRoom/ProjectProgressBar.tsx
@@ -1,13 +1,21 @@
-const ProjectProgressBar = () => {
+import { twMerge } from "tailwind-merge";
+
+interface ProjectProgressBarProps {
+  progress: number;
+}
+
+const ProjectProgressBar = ({ progress }: ProjectProgressBarProps) => {
+  console.log(progress + "");
   return (
-    <>
-      <div
-        className="w-full  h-[20px] rounded-[50px]
+    <div
+      className="w-full  h-[20px] rounded-[50px]
       bg-white border border-black"
-      >
-        <div className="bg-[#ff6854] opacity-70 w-[50%] h-full rounded-full"></div>
-      </div>
-    </>
+    >
+      <div
+        className={twMerge(`bg-[#ff6854] opacity-70 h-full rounded-full`)}
+        style={{ width: `${progress.toFixed(0)}%` }}
+      ></div>
+    </div>
   );
 };
 

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -43,7 +43,7 @@ const TaskBox = ({ isAll = true, onClick, task }: TaskBoxProps) => {
           className="w-full h-[30px] bg-gradient-to-b from-white to-main-green02 rounded-full
         flex justify-start items-center gap-2"
         >
-          <ParticipantIcon />
+          <ParticipantIcon css="w-[30px] h-[30px]" />
           <p className="font-medium text-main-green">
             {task.assignedMemberName}
           </p>

--- a/src/components/common/ParticipantIcon.tsx
+++ b/src/components/common/ParticipantIcon.tsx
@@ -1,14 +1,23 @@
 import { twMerge } from "tailwind-merge";
 
-const ParticipantIcon = ({ css }: ParticipantIconProps) => {
+const ParticipantIcon = ({ css, imgSrc }: ParticipantIconProps) => {
   // 임시 입니다 추후에 이미지로 변경예정
   return (
     <div
       className={twMerge(
         `bg-white
-        w-[30px] h-[30px] rounded-full border border-[#1F281E] ${css}`
+        w-[35px] h-[35px] rounded-full border border-[#1F281E] ${css}`
       )}
-    ></div>
+    >
+      {/* 임시 */}
+      {imgSrc && (
+        <img
+          src={imgSrc}
+          alt="프로필 이미지"
+          className="w-full h-full rounded-full"
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { createProject } from "../../utils/api/createProject";
 import "dayjs/locale/en";
+import { randomColor } from "../../utils/randomColor";
 
 const EditProjectModal = ({
   selectedProjectData,
@@ -17,9 +18,6 @@ const EditProjectModal = ({
   projectMember,
   title,
 }: EditProjectModalProps) => {
-  // // 프로젝트 생성 요청 Request
-  // const []
-
   // 프로젝트 시작 정보 초기화 상태
   const [startDateInfo, setStartDateInfo] = useState({
     year: "",
@@ -123,6 +121,7 @@ const EditProjectModal = ({
     endDate: endFormatDate,
     invitedMemberIds: selectedMembers,
     status: "BEFORE_START",
+    colors: randomColor("calendar"),
   };
 
   const { mutate } = useMutation({

--- a/src/constants/calendarColors.ts
+++ b/src/constants/calendarColors.ts
@@ -1,0 +1,42 @@
+export const CALENDAR_COLORS = [
+  {
+    background: "4cd137",
+    text: "000000",
+  },
+  {
+    background: "ff4757",
+    text: "ffffff",
+  },
+  {
+    background: "1e90ff",
+    text: "ffffff",
+  },
+  {
+    background: "8e44ad",
+    text: "ffffff",
+  },
+  {
+    background: "e67e22",
+    text: "ffffff",
+  },
+  {
+    background: "8c7ae6",
+    text: "000000",
+  },
+  {
+    background: "4b4b4b",
+    text: "ffffff",
+  },
+  {
+    background: "be2edd",
+    text: "ffffff",
+  },
+  {
+    background: "f6e58d",
+    text: "000000",
+  },
+  {
+    background: "2c2c54",
+    text: "ffffff",
+  },
+];

--- a/src/types/button.d.ts
+++ b/src/types/button.d.ts
@@ -17,4 +17,5 @@ interface AdminButtonProps {
 
 interface ParticipantIconProps {
   css?: string;
+  imgSrc?: string;
 }

--- a/src/types/projectList.d.ts
+++ b/src/types/projectList.d.ts
@@ -1,14 +1,32 @@
 interface ProjectListType {
-  id: string;
+  id: number;
   name: string;
-  color: string;
-  createdAt: string;
-  tag1: string;
-  tag2: string;
-  tag3: string;
-  startDate: string;
-  endDate: string;
-  status: string;
+  createdAt: string; // ISO8601 날짜 문자열
+  category: string;
+  subCategories1: SubCategory;
+  subCategories2: SubCategory;
+  startDate: string; // ISO8601 날짜 문자열
+  endDate: string; // ISO8601 날짜 문자열
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
+  members: Member[];
   chatRoomId: number;
-  memberNames: string[];
+  progressRate: number;
+  colors: Colors;
+}
+
+interface SubCategory {
+  name: string;
+  data: string[];
+}
+
+interface Member {
+  id: number;
+  username: string;
+  email: string;
+  profile: string; // 프로필 이미지 URL
+}
+
+interface Colors {
+  background: string; // Hex 색상 코드
+  text: string; // Hex 색상 코드
 }

--- a/src/utils/randomColor.ts
+++ b/src/utils/randomColor.ts
@@ -1,0 +1,10 @@
+import { CALENDAR_COLORS } from "../constants/calendarColors";
+
+export const randomColor = (colorType: "calendar" | "task") => {
+  const getRandomIdx = Math.floor(Math.random() * 10);
+
+  if (colorType === "calendar") {
+    const color = CALENDAR_COLORS[getRandomIdx];
+    return color;
+  }
+};


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항
- 수정된 프로젝트 리스트 mock데이터를 기반으로 메인, 프로젝트룸 페이지 수정했습니다.
- 프로젝트룸 페이지에 참여인원 이미지 적용했고 아이콘 크기 기존 30px -> 35px로 변경했습니다.
- 진행률에 맞게 데이터를 설정했습니다.
- 태그 부분에 데이터를 반영해서 적용했습니다.

- 프로젝트 생성할 때 캘린더에 표시될 프로젝트 랜덤색상 값 생성했습니다. 

## 🔗 관련 이슈

#89 

## 📸 스크린샷 (선택)
<img width="1643" alt="스크린샷 2025-02-24 오전 12 34 32" src="https://github.com/user-attachments/assets/9aa4ed8d-7fbd-4160-8c1b-fe5546e93aa7" />

