### PR TITLE
fix: 1차 QA 캘린더 높이조절 #93

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 package-lock.json
 db/*
 db.json
+.env

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -5,11 +5,12 @@ import interactionPlugin from "@fullcalendar/interaction";
 import "../../styles/Calandar.css";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getProjectList } from "../../utils/api/getProjectList";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { dragChange } from "../../utils/calendar/dragChange";
 import dayjs from "dayjs";
 import { queryClient } from "../../main";
 import { EventDropArg, EventInput } from "@fullcalendar/core/index.js";
+import { useNavigate } from "react-router";
 
 // 캘린더 상단 커스텀 버튼(프로젝트, 개인업무)
 const PROJECT_BUTTON = {
@@ -23,6 +24,8 @@ const TASK_BUTTON = {
 };
 
 const Calendar = () => {
+  const navigate = useNavigate();
+
   // fullcalandar 타입 때문에 EventInput 타입 적용
   const { data: projectListData, isLoading } = useQuery<EventInput[]>({
     queryKey: ["ProjectList"],
@@ -37,8 +40,8 @@ const Calendar = () => {
           id: project.id,
           title: project.name,
           data: project.startDate,
-          start: project.startDate.split("T")[0],
-          end: project.endDate.split("T")[0],
+          start: project.startDate,
+          end: project.endDate,
           textColor: "#" + project.colors.text,
           color: "#" + project.colors.background,
         };
@@ -76,12 +79,14 @@ const Calendar = () => {
       }}
       // 한국어
       locale={koLocale}
+      displayEventTime={false}
       // 데이터
       events={projectListData}
       // 데이터 클릭이벤트
-      eventClick={() => {
-        // alert("Event:" + info.event.title);
+      eventClick={(info) => {
+        navigate(`project-room/${info.event.id}`);
       }}
+      dayMaxEvents={3}
       // 드래그
       editable={true}
       droppable={true}


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 캘린더 데이터 값 넘칠 때 높이 늘어나게 하지 않고 + n개 이런 형식으로 수정했습니다.
- 캘린더안의 데이터 클릭시 해당 상세프로젝트로 이동하게 했습니다.

## 🔗 관련 이슈

#93 

## 📸 스크린샷 (선택)
<img width="1577" alt="스크린샷 2025-02-24 오전 11 36 49" src="https://github.com/user-attachments/assets/5c4583c4-e9ea-4257-a42e-3ee88416b73c" />


