### PR TITLE
feat: admin페이지 대시보드 데이터 연결 #132

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,5 +1,14 @@
 import { api } from "./api";
 
+// 관리자 대시보드
+export const getAdminDashboard = async () => {
+  try {
+    const { data } = await api.get("/admin/dashboard");
+    console.log(data);
+    return data;
+  } catch (error) {}
+};
+
 export const getMemberList = async () => {
   try {
     const response = await api.get("/admin/manage/member/list", {

--- a/src/components/Admin/Chart.tsx
+++ b/src/components/Admin/Chart.tsx
@@ -43,6 +43,7 @@ const Chart = ({ data, labelTitle, label }: ChartProps) => {
 
   const options: ChartOptions<"line"> = {
     responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: {
         display: true,
@@ -59,7 +60,7 @@ const Chart = ({ data, labelTitle, label }: ChartProps) => {
 
   return (
     <div className="">
-      <Line data={chartData} options={options} height={50} />
+      <Line data={chartData} options={options} height={420} />
     </div>
   );
 };

--- a/src/components/Admin/DashBoard.tsx
+++ b/src/components/Admin/DashBoard.tsx
@@ -1,37 +1,53 @@
-import { twMerge } from "tailwind-merge";
+import { useQuery } from "@tanstack/react-query";
 import Chart from "./Chart";
-import { useState } from "react";
-
-const PAY_DATA_FILTER = ["일일 매출", "월간 매출", "연간 매출"];
+import { getAdminDashboard } from "../../api/admin";
+import dayjs from "dayjs";
 
 const DashBoard = () => {
-  const [payDataTab, setPayDataTab] = useState("일일 매출");
+  const { data: dashboardData } = useQuery<DashboardType[]>({
+    queryKey: ["AdminDashboardData"],
+    queryFn: getAdminDashboard,
+  });
+
+  if (!dashboardData) {
+    return <div>로딩</div>;
+  }
+
+  const totalMembers = dashboardData[0].totalMembers;
+  const newMembers = dashboardData[0].newMembers;
 
   return (
     <div
-      className="pl-8 pr-8 h-[calc(100vh-50px)] overflow-y-scroll
+      className="pl-8 pr-8 h-[calc(100vh-50px)] 
     bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0"
     >
       <div className="bg-white/60 px-5">
         <h1 className="font-bold text-[27px] mb-4">회원 데이터</h1>
-        <p className="text-main-green font-bold mb-2">누적 회원 수</p>
         <div
           className="border border-main-green02 w-[170px] h-[50px] flex gap-2 mb-5
-          items-center justify-center text-main-green01 font-bold rounded-[10px]"
+            items-center justify-center text-main-green01 font-bold rounded-[10px]"
         >
-          총 구독 회원 <p className="text-[25px] text-header-red">127명</p>
+          총 회원{" "}
+          <p className="text-[25px] text-header-red">
+            {totalMembers[totalMembers.length - 1].totalMembers}명
+          </p>
         </div>
+        <p className="text-main-green font-bold mb-2">누적 회원 수</p>
         <Chart
-          data={[60, 80, 120, 120, 140]}
+          data={totalMembers.map((totalInfo) => totalInfo.totalMembers)}
           labelTitle="누적 회원 수"
-          label={["4주전", "3주전", "2주전", "1주전", "오늘"]}
+          label={totalMembers.map((totalInfo) =>
+            dayjs(totalInfo.startDate).format("MM/DD")
+          )}
         />
         <div className="mt-10">
           <p className="font-bold mb-5">신규 회원 수</p>
           <Chart
-            data={[30, 20, 40, 0, 15]}
+            data={newMembers.map((newInfo) => newInfo.newMembers)}
             labelTitle="신규 회원 수"
-            label={["4주전", "3주전", "2주전", "1주전", "오늘"]}
+            label={newMembers.map((newInfo) =>
+              dayjs(newInfo.date).format("MM/DD")
+            )}
           />
         </div>
       </div>

--- a/src/components/MeetingRoom/MeetingRoomChatBox.tsx
+++ b/src/components/MeetingRoom/MeetingRoomChatBox.tsx
@@ -143,7 +143,7 @@ const MeetingRoomChatBox = ({
     stompClient.publish({
       destination: "/app/chat/send",
       body: JSON.stringify({
-        senderName: "member3", // 추후 로그인한 사용자 id값으로 수정
+        senderName: "member1", // 추후 로그인한 사용자 id값으로 수정
         message: text,
         chatRoomId: messageList.groupChatRoom.chatRoomId,
         senderProfile: messageList.groupChatRoom.senderProfile, // 프로필 이미지 추가

--- a/src/components/MeetingRoom/MeetingRoomMessage.tsx
+++ b/src/components/MeetingRoom/MeetingRoomMessage.tsx
@@ -10,7 +10,7 @@ const MeetingRoomMessage = ({ messages }: { messages: MessageType[] }) => {
   return (
     <>
       {messages.map((message) =>
-        message.senderName === "member3" ? ( // 추후 senderId가 로그인한 사용자 id인지로 체크
+        message.senderName === "member1" ? ( // 추후 senderId가 로그인한 사용자 id인지로 체크
           // 사용자가 보낸 채팅일 경우 채팅만 표시 bg-main-beige
           <div
             key={message.messageId}

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -1,3 +1,18 @@
+interface TotalMember {
+  startDate: string; // "YYYY-MM-DD" 형식의 날짜
+  totalMembers: number;
+}
+
+interface NewMember {
+  date: string; // "YYYY-MM-DD" 형식의 날짜
+  newMembers: number;
+}
+
+interface DashboardType {
+  totalMembers: TotalMember[];
+  newMembers: NewMember[];
+}
+
 interface AccountListProps {
   id: number;
   email: string;


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자 대시보드 그래프 부분 데이터 연결
- 그래프 높이값 조정
- 총 구독회원 수 -> 총 회원 수로 변경

## 🔗 관련 이슈

#132 

## 📸 스크린샷 (선택)

<img width="2554" alt="스크린샷 2025-02-26 오후 11 07 58" src="https://github.com/user-attachments/assets/7b7b0e66-e7a1-4d30-a279-580f17d2ecb3" />

