### PR TITLE
Feat 관리자 계정관리 기능구현 #136

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -9,7 +9,7 @@ export const getAdminDashboard = async () => {
   } catch (error) {}
 };
 
-// 관리자 계정 관리
+// 관리자 활성 계정 관리
 export const getMemberList = async () => {
   try {
     const response = await api.get("/admin/manage/member/list", {
@@ -36,5 +36,28 @@ export const editAdminAccount = async (
     return response;
   } catch (error) {
     console.error(error);
+  }
+};
+
+// 관리자 비활성화 계정 관리
+export const getInActiveMemberList = async () => {
+  try {
+    const response = await api.get("/admin/manage/member/list", {
+      params: { deleteStatus: "deleted" },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching member list:", error);
+  }
+};
+
+// 관리자 계정 비활성(삭제)
+export const deleteAdminAccount = async (member_id: number) => {
+  try {
+    const response = api.delete(`/admin/manage/member/${member_id}/delete`);
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.log(error);
   }
 };

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -9,13 +9,32 @@ export const getAdminDashboard = async () => {
   } catch (error) {}
 };
 
+// 관리자 계정 관리
 export const getMemberList = async () => {
   try {
     const response = await api.get("/admin/manage/member/list", {
       params: { status: "active" },
     });
     console.log(response.data);
+    return response.data;
   } catch (error) {
     console.error("Error fetching member list:", error);
+  }
+};
+
+// 관리자 계정 관리 수정
+export const editAdminAccount = async (
+  member_id: number,
+  editAccountInfo: EditAccountType
+) => {
+  try {
+    const response = await api.put(
+      `/admin/manage/member/${member_id}/modify`,
+      editAccountInfo
+    );
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
   }
 };

--- a/src/components/Admin/Account/AdminAccount.tsx
+++ b/src/components/Admin/Account/AdminAccount.tsx
@@ -8,45 +8,52 @@ import { useEffect, useState } from "react";
 import Pagination from "../Pagination";
 import UnCheckBox from "../../../assets/icons/unchecked_box.svg";
 import CheckBox from "../../../assets/icons/checked_box.svg";
-import { testAPI } from "../../../api/test";
+import { useQuery } from "@tanstack/react-query";
+import { getMemberList } from "../../../api/admin";
 
 const AdminAccount = () => {
   // 더미 데이터
-  const dummyUsers: AccountListProps[] = Array.from(
-    { length: 200 },
-    (_, i) => ({
-      id: i + 1,
-      email: `user${i + 1}@example.com`,
-      name: `사용자${i + 1}`,
-      registeredDate: `2025.02.${String(i + 1).padStart(2, "0")}`,
-      profileImage: "https://via.placeholder.com/50",
-      organization: `데브코스 프론트엔드 ${(i % 3) + 1}기`,
-      isSubscribed: i % 2 === 0,
-      isActive: i % 3 !== 0,
-    })
-  );
+  // const dummyUsers: AccountListProps[] = Array.from(
+  //   { length: 200 },
+  //   (_, i) => ({
+  //     id: i + 1,
+  //     email: `user${i + 1}@example.com`,
+  //     name: `사용자${i + 1}`,
+  //     registeredDate: `2025.02.${String(i + 1).padStart(2, "0")}`,
+  //     profileImage: "https://via.placeholder.com/50",
+  //     organization: `데브코스 프론트엔드 ${(i % 3) + 1}기`,
+  //     isSubscribed: i % 2 === 0,
+  //     isActive: i % 3 !== 0,
+  //   })
+  // );
 
-  const [users, setUsers] = useState(dummyUsers);
+  // 멤버 데이터
+  const { data: AllMemberData } = useQuery<AccountListProps[]>({
+    queryKey: ["AdminAllMemberData"],
+    queryFn: getMemberList,
+  });
 
-  const handleUpdateSubscription = (id: number, isSubscribed: boolean) => {
-    setUsers((prevUsers) =>
-      prevUsers.map((user) =>
-        user.id === id ? { ...user, isSubscribed } : user
-      )
-    );
-  };
+  // const [users, setUsers] = useState(dummyUsers);
+
+  // const handleUpdateSubscription = (id: number, isSubscribed: boolean) => {
+  //   setUsers((prevUsers) =>
+  //     prevUsers.map((user) =>
+  //       user.id === id ? { ...user, isSubscribed } : user
+  //     )
+  //   );
+  // };
 
   //추후 유저 정보 업데이트 API 나오면 연동 추가
-  const handleUpdateUser = (
-    id: number,
-    updatedUser: Partial<AccountListProps>
-  ) => {
-    setUsers((prevUsers) =>
-      prevUsers.map((user) =>
-        user.id === id ? { ...user, ...updatedUser } : user
-      )
-    );
-  };
+  // const handleUpdateUser = (
+  //   id: number,
+  //   updatedUser: Partial<AccountListProps>
+  // ) => {
+  //   setUsers((prevUsers) =>
+  //     prevUsers.map((user) =>
+  //       user.id === id ? { ...user, ...updatedUser } : user
+  //     )
+  //   );
+  // };
 
   //활성계정, 비활성계정 페이지 이동과 버튼 UI변경
 
@@ -55,17 +62,19 @@ const AdminAccount = () => {
   const handleButtonClick = (type: "active" | "inactive") => {
     setUserMenu(type);
   };
-  const filteredUsers = users.filter((user) =>
-    userMenu === "active" ? user.isActive : !user.isActive
-  );
+  // const filteredUsers = users.filter((user) =>
+  //   userMenu === "active" ? user.isActive : !user.isActive
+  // );
 
   //페이지네이션
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 15; // 한 페이지에 보여줄 항목 개수
-  const totalPages = Math.ceil(users.length / itemsPerPage);
+  const totalPages = AllMemberData
+    ? Math.ceil(AllMemberData.length / itemsPerPage)
+    : 1;
 
   // 현재 페이지에 해당하는 데이터만 필터링
-  const paginatedUsers = filteredUsers.slice(
+  const paginatedUsers = AllMemberData?.slice(
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage
   );
@@ -147,16 +156,15 @@ const AdminAccount = () => {
               <span>등록일</span>
             </div>
             <div className="flex justify-center items-center">
-              <span>구독</span>
+              <span>수정</span>
             </div>
           </div>
-          {paginatedUsers.map((user, index) => (
+          {paginatedUsers?.map((user, index) => (
             <AccountList
-              key={user.id}
+              key={user.memberId}
               user={user}
               index={(currentPage - 1) * itemsPerPage + index}
-              onUpdateSubscription={handleUpdateSubscription}
-              onUpdateUser={handleUpdateUser}
+              // onUpdateUser={handleUpdateUser}
             />
           ))}
         </div>

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -11,11 +11,11 @@ import { queryClient } from "../../../main";
 const AdminAccountList = ({
   user,
   index,
-}: // onUpdateUser,
-{
+  setDeleteAccountId,
+}: {
   user: AccountListProps;
   index: number;
-  // onUpdateUser: (id: number, updatedUser: Partial<AccountListProps>) => void;
+  setDeleteAccountId: React.Dispatch<React.SetStateAction<number | null>>;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState({ ...user });
@@ -24,15 +24,6 @@ const AdminAccountList = ({
 
   const [organizationWidth, setOrganizationWidth] = useState(10);
   const [profileImageWidth, setProfileImageWidth] = useState(10);
-
-  // const handleSubscribed = () => {
-  //   onUpdateSubscription(user.id, !user.isSubscribed);
-  // };
-
-  // const handleSaveClick = () => {
-  //   setIsEditing(false);
-  //   onUpdateUser(user.id, editedUser);
-  // };
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -67,6 +58,14 @@ const AdminAccountList = ({
   };
 
   const [isChecked, setIsChecked] = useState(false);
+
+  useEffect(() => {
+    if (isChecked) {
+      setDeleteAccountId(user.memberId);
+    } else {
+      setDeleteAccountId(null);
+    }
+  }, [isChecked]);
 
   const toggleCheckBox = () => {
     setIsChecked((prev) => !prev);

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -5,19 +5,18 @@ import Button from "../../common/Button";
 import { twMerge } from "tailwind-merge";
 import UnCheckBox from "../../../assets/icons/unchecked_box.svg";
 import CheckBox from "../../../assets/icons/checked_box.svg";
+import { useMutation } from "@tanstack/react-query";
+import { editAdminAccount } from "../../../api/admin";
 
 const AdminAccountList = ({
   user,
   index,
-  onUpdateSubscription,
-  onUpdateUser,
-}: {
+}: // onUpdateUser,
+{
   user: AccountListProps;
   index: number;
-  onUpdateSubscription: (id: number, isSubscribed: boolean) => void;
-  onUpdateUser: (id: number, updatedUser: Partial<AccountListProps>) => void;
+  // onUpdateUser: (id: number, updatedUser: Partial<AccountListProps>) => void;
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState({ ...user });
   const [isComposing, setIsComposing] = useState(false);
@@ -26,19 +25,14 @@ const AdminAccountList = ({
   const [organizationWidth, setOrganizationWidth] = useState(10);
   const [profileImageWidth, setProfileImageWidth] = useState(10);
 
-  const handleDropdown = () => {
-    if (isEditing) return;
-    setIsOpen((prev) => !prev);
-  };
+  // const handleSubscribed = () => {
+  //   onUpdateSubscription(user.id, !user.isSubscribed);
+  // };
 
-  const handleSubscribed = () => {
-    onUpdateSubscription(user.id, !user.isSubscribed);
-  };
-
-  const handleSaveClick = () => {
-    setIsEditing(false);
-    onUpdateUser(user.id, editedUser);
-  };
+  // const handleSaveClick = () => {
+  //   setIsEditing(false);
+  //   onUpdateUser(user.id, editedUser);
+  // };
 
   const handleEditClick = () => setIsEditing(true);
 
@@ -79,15 +73,43 @@ const AdminAccountList = ({
   };
 
   useEffect(() => {
-    setOrganizationWidth(getTextWidth(editedUser.organization));
-    setProfileImageWidth(getTextWidth(editedUser.profileImage));
-  }, [editedUser.organization, editedUser.profileImage]);
+    setOrganizationWidth(getTextWidth(editedUser.organization || ""));
+    setProfileImageWidth(getTextWidth(editedUser.profile || ""));
+  }, [editedUser.organization, editedUser.profile]);
+
+  // 계정 관리 수정데이터
+  const editAccountData: EditAccountType = {
+    username: editedUser.username,
+    createdAt: editedUser.createdAt,
+    memberGrade: null,
+    organization: editedUser.organization,
+    profile: editedUser.profile,
+  };
+
+  // 계정관리 수정 함수
+  const { mutateAsync } = useMutation({
+    mutationFn: ({
+      memberId,
+      editAccountData,
+    }: {
+      memberId: number;
+      editAccountData: EditAccountType;
+    }) => editAdminAccount(memberId, editAccountData),
+  });
+
+  // const editAccount = async () => {
+  //   try {
+  //     const response =
+  //   } catch (error) {
+
+  //   }
+  // }
 
   return (
     <div
       className={twMerge(
-        "flex flex-col cursor-pointer",
-        isOpen ? "bg-main-green03" : "bg-transparent"
+        "flex flex-col",
+        isEditing ? "bg-main-green03" : "bg-transparent"
       )}
     >
       <div className="grid grid-cols-[5%_5%_30%_25%_25%_10%] h-[37px] w-full text-main-green text-[14px] py-[5px] ">
@@ -96,82 +118,73 @@ const AdminAccountList = ({
             <img src={isChecked ? CheckBox : UnCheckBox} alt="체크박스" />
           </button>
         </div>
-        <div
-          className="flex justify-center items-center"
-          onClick={handleDropdown}
-        >
+        <div className="flex justify-center items-center">
           <span>{index + 1}</span>
         </div>
-        <div
-          className="flex justify-center items-center"
-          onClick={handleDropdown}
-        >
+        <div className="flex justify-center items-center">
+          <span>{user.email}</span>
+        </div>
+        <div className="flex justify-center items-center">
           {isEditing ? (
             <input
               type="text"
-              name="email"
-              value={editedUser.email}
+              name="username"
+              value={editedUser.username}
               onChange={handleInputChange}
               className="h-full w-auto text-center focus:outline-none border-b border-b-header-green"
-              style={{ width: `${editedUser.email.length + 1}ch` }}
+              style={{ width: `${editedUser.username.length + 1}ch` }}
             />
           ) : (
-            <span>{user.email}</span>
+            <span>{user.username}</span>
           )}
         </div>
-        <div
-          className="flex justify-center items-center"
-          onClick={handleDropdown}
-        >
-          {isEditing ? (
-            <input
-              type="text"
-              name="name"
-              value={editedUser.name}
-              onChange={handleInputChange}
-              className="h-full w-auto text-center focus:outline-none border-b border-b-header-green"
-              style={{ width: `${editedUser.name.length + 1}ch` }}
-            />
-          ) : (
-            <span>{user.name}</span>
-          )}
-        </div>
-        <div
-          className="flex justify-center items-center"
-          onClick={handleDropdown}
-        >
+        <div className="flex justify-center items-center">
           {isEditing ? (
             <input
               type="text"
               name="registeredDate"
-              value={editedUser.registeredDate}
+              value={editedUser.createdAt}
               onChange={handleInputChange}
               className="h-full w-auto text-center focus:outline-none border-b border-b-header-green"
-              style={{ width: `${editedUser.registeredDate.length + 1}ch` }}
+              style={{ width: `${editedUser.createdAt.length + 1}ch` }}
             />
           ) : (
-            <span>{user.registeredDate}</span>
+            <span>{user.createdAt}</span>
           )}
         </div>
         <div className="flex justify-center items-center">
-          {user.isSubscribed ? (
-            <Button
-              size="sm"
-              text="비구독"
-              css="font-bold text-[14px] text-header-red border border-header-red bg-white h-[27px]"
-              onClick={handleSubscribed}
-            />
+          {isEditing ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="cursor-pointer"
+                onClick={() => {
+                  mutateAsync({ memberId: user.memberId, editAccountData });
+                  console.log(editAccountData, user.memberId);
+                }}
+              >
+                <img src={SaveIcon} alt="저장" />
+              </button>
+              <p
+                onClick={() => setIsEditing(false)}
+                className="w-[37px] h-[24px] border flex items-center justify-center rounded-[5px]
+                text-header-green border-header-green cursor-pointer"
+              >
+                취소
+              </p>
+            </div>
           ) : (
-            <Button
-              size="sm"
-              text="구독"
-              css="font-bold text-[14px] text-main-beige01 bg-header-green h-[27px]"
-              onClick={handleSubscribed}
-            />
+            <button
+              type="button"
+              onClick={handleEditClick}
+              className="cursor-pointer"
+            >
+              <img src={EditIcon} alt="수정" />
+            </button>
           )}
         </div>
       </div>
-      {isOpen && (
+      {isEditing && (
         <div>
           <div className="grid grid-cols-[10%_1fr_10%] h-[37px] w-full text-main-green text-[14px] ">
             <div></div>
@@ -182,12 +195,14 @@ const AdminAccountList = ({
                   ref={inputRef}
                   type="text"
                   name="organization"
-                  value={editedUser.organization}
+                  value={editedUser.organization || ""}
                   onChange={handleInputChange}
                   onCompositionStart={() => setIsComposing(true)}
                   onCompositionEnd={() => {
                     setIsComposing(false);
-                    setOrganizationWidth(getTextWidth(editedUser.organization));
+                    setOrganizationWidth(
+                      getTextWidth(editedUser.organization || "")
+                    );
                   }}
                   className="h-full focus:outline-none border-b border-b-header-green"
                   style={{
@@ -214,13 +229,15 @@ const AdminAccountList = ({
                 <input
                   ref={inputRef}
                   type="text"
-                  name="profileImage"
-                  value={editedUser.profileImage}
+                  name="profile"
+                  value={editedUser.profile || ""}
                   onChange={handleInputChange}
                   onCompositionStart={() => setIsComposing(true)}
                   onCompositionEnd={() => {
                     setIsComposing(false);
-                    setProfileImageWidth(getTextWidth(editedUser.profileImage));
+                    setProfileImageWidth(
+                      getTextWidth(editedUser.profile || "")
+                    );
                   }}
                   className="h-full focus:outline-none border-b border-b-header-green"
                   style={{
@@ -233,18 +250,7 @@ const AdminAccountList = ({
                   }}
                 />
               ) : (
-                <span className="flex items-center">{user.profileImage}</span>
-              )}
-            </div>
-            <div className="flex justify-center items-center">
-              {isEditing ? (
-                <button onClick={handleSaveClick} className="cursor-pointer">
-                  <img src={SaveIcon} alt="저장" />
-                </button>
-              ) : (
-                <button onClick={handleEditClick} className="cursor-pointer">
-                  <img src={EditIcon} alt="수정" />
-                </button>
+                <span className="flex items-center">{user.profile}</span>
               )}
             </div>
           </div>

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import EditIcon from "../../../assets/icons/edit.svg";
 import SaveIcon from "../../../assets/icons/save.svg";
-import Button from "../../common/Button";
 import { twMerge } from "tailwind-merge";
 import UnCheckBox from "../../../assets/icons/unchecked_box.svg";
 import CheckBox from "../../../assets/icons/checked_box.svg";
 import { useMutation } from "@tanstack/react-query";
 import { editAdminAccount } from "../../../api/admin";
+import { queryClient } from "../../../main";
 
 const AdminAccountList = ({
   user,
@@ -87,7 +87,7 @@ const AdminAccountList = ({
   };
 
   // 계정관리 수정 함수
-  const { mutateAsync } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: ({
       memberId,
       editAccountData,
@@ -95,15 +95,9 @@ const AdminAccountList = ({
       memberId: number;
       editAccountData: EditAccountType;
     }) => editAdminAccount(memberId, editAccountData),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AdminAllMemberData"] }),
   });
-
-  // const editAccount = async () => {
-  //   try {
-  //     const response =
-  //   } catch (error) {
-
-  //   }
-  // }
 
   return (
     <div
@@ -132,7 +126,7 @@ const AdminAccountList = ({
               value={editedUser.username}
               onChange={handleInputChange}
               className="h-full w-auto text-center focus:outline-none border-b border-b-header-green"
-              style={{ width: `${editedUser.username.length + 1}ch` }}
+              style={{ width: `${editedUser.username.length + 2}ch` }}
             />
           ) : (
             <span>{user.username}</span>
@@ -159,14 +153,18 @@ const AdminAccountList = ({
                 type="button"
                 className="cursor-pointer"
                 onClick={() => {
-                  mutateAsync({ memberId: user.memberId, editAccountData });
+                  mutate({ memberId: user.memberId, editAccountData });
                   console.log(editAccountData, user.memberId);
+                  setIsEditing(false);
                 }}
               >
                 <img src={SaveIcon} alt="저장" />
               </button>
               <p
-                onClick={() => setIsEditing(false)}
+                onClick={() => {
+                  setEditedUser({ ...user });
+                  setIsEditing(false);
+                }}
                 className="w-[37px] h-[24px] border flex items-center justify-center rounded-[5px]
                 text-header-green border-header-green cursor-pointer"
               >

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -14,14 +14,20 @@ interface DashboardType {
 }
 
 interface AccountListProps {
-  id: number;
+  memberId: number;
   email: string;
-  name: string;
-  registeredDate: string;
-  profileImage: string;
-  organization: string;
-  isSubscribed: boolean;
-  isActive: boolean;
+  username: string;
+  createdAt: string;
+  profile: string | null;
+  organization: string | null;
+}
+
+interface EditAccountType {
+  username: string;
+  createdAt: string;
+  memberGrade: string | null;
+  organization: string | null;
+  profile: string | null;
 }
 
 interface ProjectsListType {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자 계정관리 페이지 부분 기능 구현
- 관리자 계정 수정기능 추가 -> 날짜 수정 XXX  이름, 소속, 프로필이미지 수정가능
- 관리자 계정관리 부분 오른쪽 구독 버튼 삭제 -> 수정버튼 추가, 하단에 수정 취소버튼 추가
- 체크박스 클릭 후 삭제 가능 -> 다중 선택 XXX api상으로 하나씩만 보내게 되어있음
- 추후에 검색기능 추가 개발 필요

## 🔗 관련 이슈

#136

## 📸 스크린샷 (선택)

<img width="2260" alt="스크린샷 2025-02-27 오후 12 39 51" src="https://github.com/user-attachments/assets/4657142e-93a4-4ba9-8528-959e2d445342" />

<img width="2104" alt="스크린샷 2025-02-27 오후 12 40 10" src="https://github.com/user-attachments/assets/87b09186-ceff-454e-872a-477d88a708ff" />

<img width="2076" alt="스크린샷 2025-02-27 오후 12 40 27" src="https://github.com/user-attachments/assets/f5b50dfa-099e-4213-a994-411a0b542744" />
