### PR TITLE
feat: 관리자 업무 데이터 연결 및 수정

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -128,3 +128,41 @@ export const adminDeleteProject = async (projectId: number) => {
     console.error(error);
   }
 };
+
+// 관리자 활성 업무 리스트
+export const getAdminTaskList = async () => {
+  try {
+    const { data } = await api.get("/admin/manage/task/list");
+    console.log("adminTask", data);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 비활성 업무 리스트
+export const getAdminDeleteTaskList = async () => {
+  try {
+    const { data } = await api.get(
+      "/admin/manage/task/list?deleteStatus=deleted"
+    );
+    console.log("adminDeleteTask", data);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 업무 수정
+export const updateTask = async (taskId: number, editTaskInfo: UpdatedTask) => {
+  try {
+    const { data } = await api.put(
+      `/admin/manage/task/${taskId}/modify`,
+      editTaskInfo
+    );
+    console.log("업무 수정 성공", data);
+    return data;
+  } catch (error) {
+    console.error("업무 수정 실패", error);
+  }
+};

--- a/src/components/Admin/Task/AdminTaskList.tsx
+++ b/src/components/Admin/Task/AdminTaskList.tsx
@@ -8,16 +8,15 @@ import { PROGRESS_STATUS } from "../../../constants/status";
 import ProgressStatusBox from "../ProgressStatusBox";
 import { progressType } from "../../../utils/progressType";
 
-interface TasksListType {
-  id: number;
+interface TaskList {
+  taskId: number;
   taskName: string;
-  manager: string;
   projectName: string;
+  assignedMember: string;
+  assignedEmail: string;
   taskStatus: string;
-  createdAt: string;
   startDate: string;
   endDate: string;
-  isActive: boolean;
 }
 
 const AdminTaskList = ({
@@ -25,35 +24,54 @@ const AdminTaskList = ({
   index,
   onUpdateTask,
 }: {
-  task: TasksListType;
+  task: TaskList;
   index: number;
-  onUpdateTask: (id: number, updatedTask: Partial<TasksListType>) => void;
+  onUpdateTask: (id: number, updatedTask: TaskList) => void;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedTask, setEditedTask] = useState({ ...task });
+  // 체크 상태
+  const [isChecked, setIsChecked] = useState(false);
+  // 진행상태 체크
+  const [status, setStatus] = useState<string>(
+    PROGRESS_STATUS[task.taskStatus]!
+  );
 
+  // 저장 함수
   const handleSaveClick = () => {
     setIsEditing(false);
-    onUpdateTask(task.id, editedTask);
+    onUpdateTask(task.taskId, editedTask);
+  };
+  // console.log(editedTask);
+
+  // 기간 데이터 형식 변경 함수
+  const formatDate = (isoString: string) => {
+    const date = new Date(isoString);
+    return date
+      .toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .replace(/\. /g, "."); // 공백 제거
   };
 
+  // 기간 데이터 형식 변경
+  const formattedStartDate = formatDate(task.startDate);
+  const formattedEndDate = formatDate(task.endDate);
+
+  // 수정/저장버튼 클릭 함수
   const handleEditClick = () => setIsEditing(true);
 
+  // 내용수정 함수
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setEditedTask({ ...editedTask, [name]: value });
   };
 
-  const [isChecked, setIsChecked] = useState(false);
-
   const toggleCheckBox = () => {
     setIsChecked((prev) => !prev);
   };
-
-  // 진행상태 체크
-  const [status, setStatus] = useState<string>(
-    PROGRESS_STATUS[task.taskStatus]!
-  );
 
   useEffect(() => {
     console.log(status);
@@ -66,14 +84,15 @@ const AdminTaskList = ({
   return (
     <div
       className={twMerge(
-        "flex flex-col",
+        "flex flex-row",
         isChecked || isEditing ? "bg-main-green03" : "bg-transparent"
       )}
     >
       <div
-        className="grid grid-cols-[5%_5%_15%_20%_10%_10%_10%_20%_5%] h-[37px] w-full 
+        className="grid grid-cols-[5%_5%_10%_10%_10%_25%_10%_20%_5%] h-full w-full 
         text-main-green text-[14px] py-[5px]"
       >
+        {/* 체크박스 */}
         <div className="flex justify-center items-center">
           <button
             onClick={(e) => {
@@ -85,9 +104,12 @@ const AdminTaskList = ({
             <img src={isChecked ? CheckBox : UnCheckBox} alt="체크박스" />
           </button>
         </div>
+
+        {/* 넘버 */}
         <div className="flex justify-center items-center">
           <span>{index + 1}</span>
         </div>
+
         {/* 업무 명 */}
         <div className="flex justify-center items-center">
           {isEditing ? (
@@ -100,28 +122,35 @@ const AdminTaskList = ({
               style={{ width: `${editedTask.taskName.length + 2}ch` }}
             />
           ) : (
-            <span>{task.taskName}</span>
+            <p
+              className="whitespace-nowrap overflow-hidden text-ellipsis 
+              hover:whitespace-pre-wrap hover:overflow-visible"
+            >
+              {task.taskName}
+            </p>
           )}
         </div>
+
         {/* 프로젝트 명 */}
         <div className="flex items-center justify-center">
-          <p>{task.projectName}</p>
+          <p
+            className="whitespace-nowrap overflow-hidden text-ellipsis 
+              hover:whitespace-pre-wrap hover:overflow-visible"
+          >
+            {task.projectName}
+          </p>
         </div>
+
         {/* 담당자 */}
         <div className="flex items-center justify-center">
-          {isEditing ? (
-            <input
-              type="text"
-              name="manager"
-              value={editedTask.manager}
-              onChange={handleInputChange}
-              className="h-full w-auto text-center focus:outline-none border-b border-b-header-green"
-              style={{ width: `${editedTask.manager.length + 2}ch` }}
-            />
-          ) : (
-            <span>{task.manager}</span>
-          )}
+          <p>{task.assignedMember}</p>
         </div>
+
+        <div className="flex justify-center items-center relative">
+          <span>{task.assignedEmail}</span>
+        </div>
+
+        {/* 진행상태 */}
         <div className="flex justify-center items-center relative">
           {/* 드롭다운박스 */}
           {isEditing ? (
@@ -134,25 +163,27 @@ const AdminTaskList = ({
             <span>{status}</span>
           )}
         </div>
+
+        {/* 기간 */}
+        <div className="flex justify-center items-center">
+          <p>{formattedStartDate}</p>
+          <p>~ {formattedEndDate}</p>
+        </div>
+
+        {/* 수정/저장 버튼 */}
         <div className="flex justify-center items-center">
           {isEditing ? (
-            <span>{task.createdAt}</span>
-          ) : (
-            <span>{task.createdAt}</span>
-          )}
-        </div>
-        <div className="flex justify-center items-center">
-          <p>
-            {task.startDate} - {task.endDate}
-          </p>
-        </div>
-        <div className="flex justify-center items-center">
-          {isEditing ? (
-            <button onClick={handleSaveClick} className="cursor-pointer">
+            <button
+              onClick={handleSaveClick}
+              className="cursor-pointer w-[37px] h-[27px]"
+            >
               <img src={SaveIcon} alt="저장" />
             </button>
           ) : (
-            <button onClick={handleEditClick} className="cursor-pointer">
+            <button
+              onClick={handleEditClick}
+              className="cursor-pointer w-[37px] h-[27px]"
+            >
               <img src={EditIcon} alt="수정" />
             </button>
           )}

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -73,8 +73,7 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
 
   return (
     <div
-      className={`flex flex-col gap-4 items-center px-2 py-1 min-w-[320px] bg-white/60
-          ${!isAll ? "bg-white/60" : ""} bg-white/60`}
+      className={`flex flex-col gap-4 items-center px-2 py-1 min-w-[320px] min-h-[450px] bg-white/60`}
     >
       <h1 className="font-bold text-main-green text-[22px] sticky">{name}</h1>
       {taskInfo.map((task) => {

--- a/src/components/modals/UpdateTaskModal.tsx
+++ b/src/components/modals/UpdateTaskModal.tsx
@@ -88,7 +88,7 @@ const UpdateTaskModal = ({
       username: task.assignedMemberName,
       profile: updatedData?.participantProfiles[0] || "",
       email: "",
-      id: updatedData?.participantIds[0] || 0,
+      memberId: updatedData?.participantIds[0] || 0,
     },
   ]);
 
@@ -109,8 +109,8 @@ const UpdateTaskModal = ({
     startDate: formatDateTime(selectedStartDate),
     endDate: formatDateTime(selectedEndDate),
     status: reversedStatusOptions[selectedStatus],
-    assignedMemberId: memberData[0].id,
-    participantIds: [memberData[0].id],
+    assignedMemberId: memberData[0].memberId,
+    participantIds: [memberData[0].memberId],
   };
 
   // console.log(task);

--- a/src/types/task.d.ts
+++ b/src/types/task.d.ts
@@ -90,3 +90,8 @@ interface ManageTasksType {
   name: string;
   tasks: Task[];
 }
+
+interface UpdatedTask {
+  taskName: string;
+  taskStatus: string;
+}


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 담당자별 업무리스트에서 배정된 업무가 없더라도 기본 백그라운드가 보이게 변경하였습니다.
- 관리자 업무 페이지에서 업무 리스트 api 호출로 데이터를 연결하였습니다.
- 업무 수정 api 연결하여 기능 구현하였습니다. (업무명, 진행상태만 변경 가능하도록 변경)
- 비활성 업무 리스트를 받아와서 활성 / 비활성 탭으로 구분하였습니다.

## 🔗 관련 이슈

- 관련된 이슈 번호를 적어주세요. (예: `#3`)

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
