### PR TITLE
<Merge/fix_관리자-계정검색-오류수정_#189>fix: 관리자계정프로젝트검색수정 #189

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,11 +1,26 @@
 import { api } from "./api";
 
-// 멤버 검색 API
+// 멤버 검색 API (활성 멤버만)
 export const searchMembers = async (
   name: string
 ): Promise<SearchMemberType[]> => {
   try {
     const response = await api.get(`/api/search/members`, {
+      params: { name },
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching members:", error);
+    throw error;
+  }
+};
+// 멤버 검색 API (비활성 멤버 포함)
+export const searchAllMembers = async (
+  name: string
+): Promise<SearchMemberType[]> => {
+  try {
+    const response = await api.get(`/api/search/admin/members`, {
       params: { name },
     });
     console.log(response.data);

--- a/src/components/Admin/Account/AdminAccount.tsx
+++ b/src/components/Admin/Account/AdminAccount.tsx
@@ -15,7 +15,7 @@ import {
   getMemberList,
 } from "../../../api/admin";
 import { queryClient } from "../../../main";
-import { searchMembers } from "../../../api/search";
+import { searchAllMembers } from "../../../api/search";
 import AlertModal from "../../common/AlertModal";
 
 const AdminAccount = () => {
@@ -49,9 +49,9 @@ const AdminAccount = () => {
     null
   );
 
-  const { data: searchedMembers, refetch } = useQuery<SearchMemberType[]>({
+  const { data: searchedAllMembers, refetch } = useQuery<SearchMemberType[]>({
     queryKey: ["searchedMembers", searchName],
-    queryFn: () => searchMembers(searchName),
+    queryFn: () => searchAllMembers(searchName),
     enabled: false,
   });
 
@@ -93,6 +93,15 @@ const AdminAccount = () => {
       );
     }
   }, [searchName, userMenu, AllMemberData, inActiveMemberData]);
+
+  // 탭 변경 시 검색 결과 초기화
+  useEffect(() => {
+    setSearchName(""); // 검색어 초기화
+    setSearchResult(null); // 검색 결과 초기화
+    setMemberData(
+      userMenu === "active" ? AllMemberData || [] : inActiveMemberData || []
+    );
+  }, [userMenu, AllMemberData, inActiveMemberData]);
 
   //검색 결과가 업데이트되면 `memberData`에 반영
   useEffect(() => {

--- a/src/components/Admin/Project/AdminProject.tsx
+++ b/src/components/Admin/Project/AdminProject.tsx
@@ -90,6 +90,17 @@ const AdminProject = () => {
     setProjectData(filteredData);
   }, [projectMenu, selectedProjects, searchResult]);
 
+  // 탭 변경 시 검색 결과 초기화
+  useEffect(() => {
+    setSearchProjectName(""); // 검색어 초기화
+    setSearchResult(null); // 검색 결과 초기화
+    setProjectData(
+      projectMenu === "active"
+        ? adminActiveProject || []
+        : adminInActiveProject || []
+    );
+  }, [projectMenu, adminActiveProject, adminInActiveProject]);
+
   //페이지네이션
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 15; // 한 페이지에 보여줄 항목 개수

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -65,7 +65,7 @@ const ConfirmModal = ({
 
             if (processType === "프로젝트" && deleteOrLeave) {
               deleteOrLeave(); // 프로젝트 삭제 / 나가기 함수
-              openModal(`${value}성공!`);
+              // openModal(`${value}성공!`);
               // setIsModal(false);
             } else if (
               processId &&


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

1. 관리자 계정 검색에서 비활성 검색 안되는 부분 API 추가해 수정했습니다
2. 관리자 계정, 프로젝트 검색에서 활성, 비활성 탭 바꾸면 검색 리셋되도록 수정했습니다

## 🔗 관련 이슈

- #189

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
