### PR TITLE
Feat 관리자페이지 업무 삭제 메인페이지 업무 기능 #183

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -170,7 +170,7 @@ export const updateTask = async (taskId: number, editTaskInfo: UpdatedTask) => {
 // 관리자 업무 삭제
 export const deleteTask = async (taskId: number) => {
   try {
-    const { data } = await api.put(`/admin/manage/task/${taskId}/delete`);
+    const { data } = await api.delete(`/admin/manage/task/${taskId}/delete`);
     console.log("업무 삭제 성공", data);
     return data;
   } catch (error) {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -166,3 +166,14 @@ export const updateTask = async (taskId: number, editTaskInfo: UpdatedTask) => {
     console.error("업무 수정 실패", error);
   }
 };
+
+// 관리자 업무 삭제
+export const deleteTask = async (taskId: number) => {
+  try {
+    const { data } = await api.put(`/admin/manage/task/${taskId}/delete`);
+    console.log("업무 삭제 성공", data);
+    return data;
+  } catch (error) {
+    console.error("업무 삭제 실패", error);
+  }
+};

--- a/src/components/Admin/Task/AdminTaskList.tsx
+++ b/src/components/Admin/Task/AdminTaskList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import EditIcon from "../../../assets/icons/edit.svg";
 import SaveIcon from "../../../assets/icons/save.svg";
 import { twMerge } from "tailwind-merge";
@@ -23,10 +23,16 @@ const AdminTaskList = ({
   task,
   index,
   onUpdateTask,
+  page,
+  isAllCheck,
+  setIsCheckedId,
 }: {
   task: TaskList;
   index: number;
   onUpdateTask: (id: number, updatedTask: TaskList) => void;
+  page: number;
+  isAllCheck: boolean;
+  setIsCheckedId: React.Dispatch<React.SetStateAction<number[]>>;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedTask, setEditedTask] = useState({ ...task });
@@ -36,6 +42,24 @@ const AdminTaskList = ({
   const [status, setStatus] = useState<string>(
     PROGRESS_STATUS[task.taskStatus]!
   );
+
+  // 전체 체크 시 선택 함수
+  useEffect(() => {
+    isAllCheck && page - 1 <= index && page - 1 + 14 >= index
+      ? setIsChecked(true)
+      : setIsChecked(false);
+  }, [isAllCheck, page]);
+
+  // 체크 시 체크된 항목 배열에 id 추가
+  useEffect(() => {
+    setIsCheckedId((prev) =>
+      isChecked
+        ? prev.includes(task.taskId)
+          ? prev
+          : [...prev, task.taskId]
+        : prev.filter((prevIds) => prevIds !== task.taskId)
+    );
+  }, [isChecked]);
 
   // 저장 함수
   const handleSaveClick = () => {

--- a/src/components/EditProjectModal/SelectMember.tsx
+++ b/src/components/EditProjectModal/SelectMember.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { searchMembers } from "../../api/search";
 import { debounce } from "lodash";
 import { useAuthStore } from "../../store/authStore";
+import AlertModal from "../modals/AlertModal";
 
 type SelectMembersProps<T extends "업무" | "프로젝트"> = {
   selectedData?: T extends "프로젝트" ? ProjectDataType : UpdateTask;
@@ -10,6 +11,7 @@ type SelectMembersProps<T extends "업무" | "프로젝트"> = {
   setSelectedMembers?: React.Dispatch<React.SetStateAction<MemberType[]>>;
   value: T;
   type?: string;
+  memberData?: members[];
 };
 
 const SelectMember = <T extends "업무" | "프로젝트">({
@@ -18,10 +20,12 @@ const SelectMember = <T extends "업무" | "프로젝트">({
   setSelectedMembers,
   value,
   type,
+  memberData,
 }: SelectMembersProps<T>) => {
   const loginUser = useAuthStore((state) => state.member);
+  const [isModal, setIsModal] = useState<boolean>(false);
 
-  console.log(selectedData);
+  console.log(memberData);
 
   useEffect(() => {
     console.log(selectedData);
@@ -70,7 +74,6 @@ const SelectMember = <T extends "업무" | "프로젝트">({
     }
 
     // 이미 선택된 팀원이 있는지 확인
-
     const isSelected = selectedMembers?.some(
       (selected) => selected.memberId === member.memberId
     );
@@ -78,7 +81,10 @@ const SelectMember = <T extends "업무" | "프로젝트">({
     if (!isSelected && setSelectedMembers) {
       // 업무박스에선 한 명만 선택되도록 함
       if (value === "업무") {
-        setSelectedMembers([member]);
+        // 선택인원이 프로젝트 참여인원이 아닐 때 모달 오픈
+        if (memberData?.some((m) => m.memberId !== member.memberId)) {
+          setIsModal(true);
+        } else setSelectedMembers([member]);
       } else {
         setSelectedMembers((prevSelected: MemberType[]) =>
           [...prevSelected, member].sort((a, b) =>
@@ -177,6 +183,20 @@ const SelectMember = <T extends "업무" | "프로젝트">({
           </div>
         ))}
       </div>
+
+      {/* 참여인원 확인 모달 */}
+      {isModal && (
+        <div
+          className="absolute inset-0 w-screen h-fit min-h-screen
+            flex justify-center items-center bg-black/70 z-50"
+          onClick={() => setIsModal(false)}
+        >
+          <AlertModal
+            text="프로젝트 참여인원이 아닙니다."
+            setIsModal={setIsModal}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/EditProjectModal/SelectMember.tsx
+++ b/src/components/EditProjectModal/SelectMember.tsx
@@ -82,7 +82,7 @@ const SelectMember = <T extends "업무" | "프로젝트">({
       // 업무박스에선 한 명만 선택되도록 함
       if (value === "업무") {
         // 선택인원이 프로젝트 참여인원이 아닐 때 모달 오픈
-        if (memberData?.some((m) => m.memberId !== member.memberId)) {
+        if (!memberData?.some((m) => m.memberId === member.memberId)) {
           setIsModal(true);
         } else setSelectedMembers([member]);
       } else {

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -143,12 +143,20 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
                 text={"시작"}
                 size="md"
                 css="border-main-green01 h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-green01 bg-main-green02"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleStateStart();
+                }}
               />
             ) : (
               <Button
                 text={"완료"}
                 size="md"
                 css="border-none h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-beige01 bg-main-green01"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCompleteStart();
+                }}
               />
             ))}
         </div>

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -3,8 +3,12 @@ import { PROGRESS_STATUS } from "../../constants/status";
 import Button from "../common/Button";
 import ParticipantIcon from "../common/ParticipantIcon";
 import { getTaskById } from "../../api/task";
+import { useAuthStore } from "../../store/authStore";
 
 const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
+  const { member } = useAuthStore();
+
+  // 업무 수정
   const { data: updatedData } = useQuery<GetUpdateTask>({
     queryKey: ["UpdatedData", task.taskId],
     queryFn: async () => {
@@ -45,8 +49,12 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
   if (isAll && updatedData) {
     return (
       <div
-        className="w-[320px] h-[120px] bg-white border border-main-green02
-        px-3 py-2 flex flex-col justify-center gap-2 cursor-pointer"
+        className={`w-[320px] h-[120px] bg-white border border-main-green02
+        px-3 py-2 flex flex-col justify-center gap-2 ${
+          task.assignedMemberName === member?.username &&
+          "cursor-pointer transition-all duration-500 transform hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
+        } 
+        `}
         onClick={onClick}
       >
         <div className="flex justify-between items-center">
@@ -62,27 +70,28 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
             {updatedData.startDate.split("T")[0]} ~{" "}
             {updatedData.endDate.split("T")[0]}
           </p>
-          {task.status !== "IN_PROGRESS" ? (
-            <Button
-              text={"시작"}
-              size="md"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleStateStart();
-              }}
-              css="border-main-green01 h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-green01 bg-main-green02"
-            />
-          ) : (
-            <Button
-              text={"완료"}
-              size="md"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleCompleteStart();
-              }}
-              css="border-none h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-beige01 bg-main-green01"
-            />
-          )}
+          {task.assignedMemberName === member?.username &&
+            (task.status !== "IN_PROGRESS" ? (
+              <Button
+                text={"시작"}
+                size="md"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleStateStart();
+                }}
+                css="border-main-green01 h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-green01 bg-main-green02"
+              />
+            ) : (
+              <Button
+                text={"완료"}
+                size="md"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCompleteStart();
+                }}
+                css="border-none h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-beige01 bg-main-green01"
+              />
+            ))}
         </div>
 
         {/* 담당자 */}
@@ -105,11 +114,19 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
     /* 로그인 유저의 업무인지 확인하여 편집가능하게 해야 함 */
     return (
       <div
-        className="w-[300px] h-[80px] bg-white border border-main-green02 
-        px-3 py-2 flex flex-col justify-center gap-2"
+        className={`w-[300px] h-[80px] bg-white border border-main-green02
+        px-3 py-2 flex flex-col justify-center gap-2 ${
+          task.assignedMemberName === member?.username &&
+          "cursor-pointer transition-all duration-500 transform hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
+        } 
+        `}
+        onClick={onClick}
       >
         <div className="flex justify-between items-center">
+          {/* 업무명 */}
           <p className="font-bold">{task.title}</p>
+
+          {/* 진행상태 */}
           <p className="text-[12px] font-medium">
             {PROGRESS_STATUS[task.status]}
           </p>
@@ -120,19 +137,20 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
           <p className="text-[12px]">
             {task.startDate.split("T")[0]} ~ {task.endDate.split("T")[0]}
           </p>
-          {task.status !== "IN_PROGRESS" ? (
-            <Button
-              text={"시작"}
-              size="md"
-              css="border-main-green01 h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-green01 bg-main-green02"
-            />
-          ) : (
-            <Button
-              text={"완료"}
-              size="md"
-              css="border-none h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-beige01 bg-main-green01"
-            />
-          )}
+          {task.assignedMemberName === member?.username &&
+            (task.status !== "IN_PROGRESS" ? (
+              <Button
+                text={"시작"}
+                size="md"
+                css="border-main-green01 h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-green01 bg-main-green02"
+              />
+            ) : (
+              <Button
+                text={"완료"}
+                size="md"
+                css="border-none h-[22px] w-fit px-[10px] py-[2px] font-normal text-[14px] rounded-[4px] text-main-beige01 bg-main-green01"
+              />
+            ))}
         </div>
       </div>
     );

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -52,7 +52,7 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
         className={`w-[320px] h-[120px] bg-white border border-main-green02
         px-3 py-2 flex flex-col justify-center gap-2 ${
           task.assignedMemberName === member?.username &&
-          "cursor-pointer transition-all duration-500 transform hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
+          "cursor-pointer transition-transform duration-500  hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
         } 
         `}
         onClick={onClick}
@@ -117,7 +117,7 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
         className={`w-[300px] h-[80px] bg-white border border-main-green02
         px-3 py-2 flex flex-col justify-center gap-2 ${
           task.assignedMemberName === member?.username &&
-          "cursor-pointer transition-all duration-500 transform hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
+          "cursor-pointer transition-transform duration-500 hover:scale-105 hover:border-[3px] hover:border-main-green01 hover:rounded-[10px]"
         } 
         `}
         onClick={onClick}

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -3,9 +3,12 @@ import TaskBox from "./TaskBox";
 import UpdateTaskModal from "../modals/UpdateTaskModal";
 import { useMutation } from "@tanstack/react-query";
 import { deleteTask, updateTask } from "../../api/task";
+import { useAuthStore } from "../../store/authStore";
 
 const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const { member } = useAuthStore();
+  // console.log(member);
 
   const openModal = (task: Task) => {
     setSelectedTask(task); // 임의로 첫 번째 더미 데이터를 선택
@@ -75,13 +78,13 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
     <div
       className={`flex flex-col gap-4 items-center px-2 py-1 min-w-[320px] min-h-[450px] bg-white/60`}
     >
-      <h1 className="font-bold text-main-green text-[22px] sticky">{name}</h1>
+      <h1 className="font-bold text-main-green text-[22px]">{name}</h1>
       {taskInfo.map((task) => {
         return (
           <TaskBox
             key={task.taskId}
             onClick={() => {
-              openModal(task);
+              task.assignedMemberName === member?.username && openModal(task);
             }}
             isAll={isAll}
             task={task}

--- a/src/components/layout/ManagerCheckBox.tsx
+++ b/src/components/layout/ManagerCheckBox.tsx
@@ -38,7 +38,7 @@ const ManagerCheckBox = ({
         <img
           src={sideCheckIcon}
           alt="checked"
-          className="w-[11px] h-[11px] hidden peer-checked:block absolute left-[1px]"
+          className="w-[11px] h-[11px] hidden peer-checked:block absolute left-[1px] cursor-pointer"
         />
 
         <span className="peer-checked:text-header-green-hover cursor-pointer">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -68,6 +68,23 @@ const Sidebar = ({
     (state) => state.handleManagerClick
   );
 
+  // 담당자 정렬 상태
+  const [sortedManagers, setSortedManagers] = useState<members[]>([]);
+
+  useEffect(() => {
+    // managers 배열을 정렬하여 상태에 저장
+    const sorted = [...managers].sort((a, b) => {
+      if (a.username < b.username) {
+        return -1;
+      }
+      if (a.username > b.username) {
+        return 1;
+      }
+      return 0;
+    });
+    setSortedManagers(sorted);
+  }, [managers]);
+
   useEffect(() => {
     if (managers.length > 0 && projectRoomMenu === "manager") {
       // 초기 체크박스 전체선택
@@ -144,7 +161,7 @@ const Sidebar = ({
                     />
 
                     {/* 담당자별 */}
-                    {managers.map((member) => (
+                    {sortedManagers.map((member) => (
                       <ManagerCheckBox
                         key={member.memberId}
                         checkboxName={member.username}

--- a/src/components/modals/AlertModal.tsx
+++ b/src/components/modals/AlertModal.tsx
@@ -1,0 +1,30 @@
+import Button from "../common/Button";
+
+const AlertModal = ({
+  text,
+  setIsModal,
+}: {
+  text: string;
+  setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  return (
+    <div
+      className="bg-white text-main-green px-[100px] py-[50px] gap-[30px]
+  flex flex-col justify-center items-center z-10"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <p>{text}</p>
+      <Button
+        text="확인"
+        size="md"
+        css="w-fit h-fit px-[10px] py-[5px] text-main-beige01 bg-logo-green"
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsModal(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default AlertModal;

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -8,12 +8,14 @@ const ConfirmModal = ({
   setIsModal,
   deleteOrLeave,
   onClick,
+  onDeleteTask,
 }: {
   processId?: number;
   processType?: string;
   value: string;
   setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
   onClick?: (processId: number) => void;
+  onDeleteTask?: () => void;
   deleteOrLeave?: () => void;
 }) => {
   const { logout } = useAuthStore();
@@ -59,6 +61,12 @@ const ConfirmModal = ({
             ) {
               console.log("삭제 버튼 클릭됨"); // 디버깅용 로그
               onClick(processId);
+            }
+
+            if (processType === "업무" && value === "삭제" && onDeleteTask) {
+              console.log("삭제 버튼 클릭됨");
+              onDeleteTask();
+              setIsModal(false);
             }
           }}
         />

--- a/src/components/modals/CreateTaskModal.tsx
+++ b/src/components/modals/CreateTaskModal.tsx
@@ -6,11 +6,21 @@ import SelectMember from "../EditProjectModal/SelectMember";
 import { useMutation } from "@tanstack/react-query";
 import { createTask } from "../../api/task";
 
+interface CreateTaskProps {
+  onClose: React.Dispatch<React.SetStateAction<boolean>>;
+  projectId: number;
+  onClick?: (task: CreateTask) => void;
+  refetch: () => void;
+  setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
+  memberData: members[];
+}
+
 const CreateTaskModal = ({
   onClose,
   projectId,
   refetch,
   setIsModal,
+  memberData,
 }: CreateTaskProps) => {
   /* 업무 생성 */
   const { mutateAsync } = useMutation({
@@ -117,6 +127,7 @@ const CreateTaskModal = ({
         value="업무"
         selectedMembers={selectedMember}
         setSelectedMembers={setSelectedMember}
+        memberData={memberData}
       />
       <div>
         <span className="text-[16px] font-bold">일정</span>

--- a/src/pages/ProjectRoom/ProjectRoomDetail.tsx
+++ b/src/pages/ProjectRoom/ProjectRoomDetail.tsx
@@ -9,6 +9,45 @@ import { OutletContextType } from "../../components/layout/Layout";
 import { useSideManagerStore } from "../../store/sideMemberStore";
 import { getProjectDetail } from "../../api/project";
 
+interface ProjectDetailType {
+  projectId: number;
+  projectName: string;
+  categoryName: string;
+  subCategories: subCategories[];
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
+  tasks: Task[];
+  members: members[];
+}
+
+interface subCategories {
+  id: number;
+  name: string;
+  tags: tags[];
+}
+
+interface tags {
+  id: number;
+  name: string;
+}
+
+interface members {
+  memberId: number;
+  username: string;
+  profile: string;
+}
+
+interface ManageTasksType {
+  name: string;
+  tasks: Task[];
+}
+
+interface AllTasksType {
+  IN_PROGRESS: Task[];
+  COMPLETED: Task[];
+  BEFORE_START: Task[];
+  HOLD: Task[];
+}
+
 const ProjectRoomDetail = () => {
   const { projectId } = useParams();
   const [searchParams] = useSearchParams();
@@ -17,7 +56,7 @@ const ProjectRoomDetail = () => {
 
   const { setManagers } = useOutletContext<OutletContextType>();
 
-  // 프로젝트 상세 정보 불러오기
+  /* 프로젝트 상세 정보 불러오기 */
   const {
     data: projectDetailList,
     isLoading,
@@ -28,7 +67,7 @@ const ProjectRoomDetail = () => {
       return await getProjectDetail(Number(projectId!));
     },
   });
-  // console.log(projectDetailList);
+  console.log(projectDetailList?.members);
 
   // 전체 업무 상태
   const [allTasks, setAllTasks] = useState<AllTasksType>({
@@ -38,12 +77,20 @@ const ProjectRoomDetail = () => {
     HOLD: [],
   });
 
-  interface ManageTasksType {
-    name: string;
-    tasks: Task[];
-  }
-
+  // 담당자 업무 상태
   const [manageTasks, setManageTasks] = useState<ManageTasksType[]>([]);
+  // 프로젝트 참여자 상태
+  const [member, setMember] = useState<members[]>(
+    projectDetailList?.members || []
+  );
+
+  useEffect(() => {
+    if (projectDetailList) {
+      setMember(projectDetailList.members);
+    }
+  }, [projectDetailList]);
+
+  console.log(member);
 
   useEffect(() => {
     console.log(projectDetailList, isLoading);
@@ -141,20 +188,20 @@ const ProjectRoomDetail = () => {
               {/* 태그 목록 */}
               <div className="flex justify-start gap-[10px]">
                 {/* 분야 */}
-                {projectDetailList?.category && (
-                  <p># {projectDetailList?.category}</p>
+                {projectDetailList?.categoryName && (
+                  <p># {projectDetailList?.categoryName}</p>
                 )}
 
                 {/* 세부분야 1 */}
-                {projectDetailList?.subCategories1 &&
-                  projectDetailList?.subCategories1.map((item) => (
-                    <p key={item}># {item}</p>
+                {projectDetailList?.subCategories[0] &&
+                  projectDetailList?.subCategories[0].tags.map((item) => (
+                    <p key={item.name}># {item.name}</p>
                   ))}
 
                 {/* 세부분야2 */}
-                {projectDetailList?.subCategories2 &&
-                  projectDetailList?.subCategories2.map((item) => (
-                    <p key={item}># {item}</p>
+                {projectDetailList?.subCategories[1] &&
+                  projectDetailList?.subCategories[1].tags.map((item) => (
+                    <p key={item.name}># {item.name}</p>
                   ))}
               </div>
             </div>
@@ -234,6 +281,7 @@ const ProjectRoomDetail = () => {
                 projectId={Number(projectId)}
                 refetch={refetch}
                 setIsModal={setIsEditTaskModal}
+                memberData={member}
               />
             </div>
           )}

--- a/src/types/projectDetailList.d.ts
+++ b/src/types/projectDetailList.d.ts
@@ -1,41 +1,43 @@
-// 임시
-interface TaskType {
+interface ProjectDetailType {
+  projectId: number;
+  projectName: string;
+  categoryName: string;
+  subCategories: subCategories[];
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
+  tasks: tasks[];
+  members: members[];
+}
+
+interface subCategories {
+  id: number;
+  name: string;
+  tags: tags[];
+}
+
+interface tags {
+  id: number;
+  name: string;
+}
+
+interface tasks {
   taskId: number;
   title: string;
   startDate: string;
   endDate: string;
-  status: "IN_PROGRESS" | "COMPLETED" | "BEFORE_START" | "HOLD";
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED" | "HOLD";
   assignedMemberName: string;
+  assignedMemberProfile: string | null;
+  participants: string[];
+  colors: colors;
 }
 
-interface ProjectDetailListType {
-  projectId: number;
-  projectName: string;
-  tasks: Task[];
-  members: {
-    id: number;
-    username: string;
-    email: string;
-    profile: string;
-  }[];
+interface colors {
+  background: string; // Hex 색상 코드
+  text: string; // Hex 색상 코드
 }
 
-interface ProjectDetailType {
-  category: string;
-  members: {
-    id: number;
-    username: string;
-    profile: string;
-  }[];
-  projectId: number;
-  projectName: string;
-  subCategories1: string[];
-  subCategories2: string[];
-  tasks: Task[];
-}
-
-interface ProjectMembers {
-  id: number;
+interface members {
+  memberId: number;
   username: string;
-  profile: string;
+  profile: string | null;
 }

--- a/src/types/projectList.d.ts
+++ b/src/types/projectList.d.ts
@@ -14,45 +14,19 @@ interface ProjectListType {
   colors: Colors;
 }
 
-interface ProjectDetailType {
-  id: number;
-  name: string;
-  createdAt: string; // ISO8601 날짜 문자열
-  category: string;
-  subCategories1: SubCategory;
-  subCategories2: SubCategory;
-  startDate: string; // ISO8601 날짜 문자열
-  endDate: string; // ISO8601 날짜 문자열
-  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
-  memberNames: string[];
-  memberProfiles: string[];
-  chatRoomId: number;
-  progressRate: number;
-  colors: Colors;
-}
-
-interface ProjectDetailType {
-  id: number;
-  name: string;
-  createdAt: string; // ISO8601 날짜 문자열
-  category: string;
-  subCategories1: string[];
-  subCategories2: string[];
-  startDate: string; // ISO8601 날짜 문자열
-  endDate: string; // ISO8601 날짜 문자열
-  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
-  members: MemberType[];
-  chatRoomId: number;
-  progressRate: number;
-  colors: Colors;
-}
-
-interface SubCategory {
-  name: string;
-  data: string[];
-}
-
-interface Colors {
-  background: string; // Hex 색상 코드
-  text: string; // Hex 색상 코드
-}
+// interface ProjectDetailType {
+//   id: number;
+//   name: string;
+//   createdAt: string; // ISO8601 날짜 문자열
+//   category: string;
+//   subCategories1: SubCategory;
+//   subCategories2: SubCategory;
+//   startDate: string; // ISO8601 날짜 문자열
+//   endDate: string; // ISO8601 날짜 문자열
+//   status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
+//   memberNames: string[];
+//   memberProfiles: string[];
+//   chatRoomId: number;
+//   progressRate: number;
+//   colors: Colors;
+// }

--- a/src/types/task.d.ts
+++ b/src/types/task.d.ts
@@ -17,14 +17,6 @@ interface selectedDateType {
   ampm: string;
 }
 
-interface CreateTaskProps {
-  onClose: React.Dispatch<React.SetStateAction<boolean>>;
-  projectId: number;
-  onClick?: (task: CreateTask) => void;
-  refetch: () => void;
-  setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
 interface TaskListProps {
   name: string;
   isAll?: boolean;
@@ -39,12 +31,6 @@ interface TaskBoxProps {
   onUpdate?: (taskId: number, updateData: UpdateTask) => void;
 }
 
-interface AllTasksType {
-  IN_PROGRESS: Task[];
-  COMPLETED: Task[];
-  BEFORE_START: Task[];
-  HOLD: Task[];
-}
 interface Task {
   taskId: number;
   title: string;
@@ -54,6 +40,7 @@ interface Task {
   assignedMemberName: string;
   assignedMemberProfile: string; // URL 형식으로 처리
   participants: string[]; // 참가자는 문자열 배열로 처리
+  colors: { background: string; text: string };
 }
 
 interface CreateTask {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자 업무 페이지 - 업무 삭제 기능을 구현했습니다.
- 관리자 업무 페이지 - 기능이 사라진 버튼들을 정리했습니다.
- 프로젝트 상세 페이지 - 기존 발생한 타입 오류를 해결하고 타입을 일부 정리했습니다.
- 프로젝트 상세 페이지 - 사이드바 담당자 체크박스를 글자순으로 정렬했습니다.
- 프로젝트 상세 페이지 - 담당이 아닌 업무는 편집이 불가하도록 설정했습니다.
- 프로젝트 상세 페이지 - 담당 업무박스는 hover 시 디자인을 추가하여 가독성을 개선했습니다.
- 프로젝트 상세 페이지 - 업무 생성 및 편집 시 지정 가능한 담당자를 프로젝트 참여인원에 한정했습니다.

진행 중인 내용
- 메인 페이지 내 업무 관련 사항들
- 관리자 업무 페이지 내 업무 검색 기능

## 🔗 관련 이슈

- 관련된 이슈 번호를 적어주세요. (예: `#3`)

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/bc71ba0e-c4f7-411e-a35a-86eb873ef997)
![image](https://github.com/user-attachments/assets/912645ff-7b9c-4ed1-901a-5b2679af07c3)
