### PR TITLE
Feat 관리자페이지 태그부분 구현 #179

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -64,17 +64,6 @@ export const deleteAdminAccount = async (member_id: number) => {
   }
 };
 
-// 관리자 카테고리 전체 조회
-export const getAllCategory = async () => {
-  try {
-    const { data } = await api.get("/admin/manage/category/list");
-    console.log(data);
-    return data;
-  } catch (error) {
-    console.error(error);
-  }
-};
-
 // 관리자 활성 프로젝트 리스트
 export const getAdminProjectList = async () => {
   try {

--- a/src/api/adminCategory.ts
+++ b/src/api/adminCategory.ts
@@ -1,0 +1,53 @@
+import { api } from "./api";
+
+// 관리자 카테고리 전체 조회
+export const getAllCategory = async () => {
+  try {
+    const { data } = await api.get("/admin/manage/category/list");
+    console.log(data);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const adminNewCategory = async (newCategoryName: string) => {
+  try {
+    const response = api.post("/admin/manage/category/create", {
+      name: newCategoryName,
+    });
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 카테고리 수정
+export const adminEditCategory = async (
+  categoryId: number,
+  editedName: string
+) => {
+  try {
+    const response = await api.put(
+      `/admin/manage/category/${categoryId}/modify`,
+      {
+        name: editedName,
+      }
+    );
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 카테고리 삭제
+export const adminDeleteCategory = async (categoryId: number) => {
+  try {
+    const response = await api(`/admin/manage/category/${categoryId}/delete`);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/adminCategory.ts
+++ b/src/api/adminCategory.ts
@@ -36,6 +36,9 @@ export const adminEditCategory = async (
       }
     );
     console.log(response);
+    if (response.status === 204) {
+      alert("카테고리 수정이 완료되었습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -45,7 +48,13 @@ export const adminEditCategory = async (
 // 관리자 카테고리 삭제
 export const adminDeleteCategory = async (categoryId: number) => {
   try {
-    const response = await api(`/admin/manage/category/${categoryId}/delete`);
+    const response = await api.delete(
+      `/admin/manage/category/${categoryId}/delete`
+    );
+    console.log("adminDeleteCategory", response);
+    if (response.status === 204) {
+      alert("카테고리가 삭제되었습니다");
+    }
     return response;
   } catch (error) {
     console.error(error);

--- a/src/api/adminDetailTag.ts
+++ b/src/api/adminDetailTag.ts
@@ -34,6 +34,9 @@ export const adminEditDetailTag = async (
       }
     );
     console.log("adminEditDetailTag", response);
+    if (response.status === 200) {
+      alert("태그가 수정되었습니다");
+    }
     return response;
   } catch (error) {
     console.error(error);

--- a/src/api/adminDetailTag.ts
+++ b/src/api/adminDetailTag.ts
@@ -1,0 +1,61 @@
+import { api } from "./api";
+
+// 관리자 상세항목 태그 생성
+export const adminAddnewDetailTag = async (
+  subcategoryId: number,
+  newDetailTagName: string
+) => {
+  try {
+    const response = await api.post(
+      `/admin/manage/subcategory/${subcategoryId}/tag/create`,
+      {
+        name: newDetailTagName,
+      }
+    );
+    console.log("adminAddnewDetailTag", response);
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 상세항목 태그 수정
+export const adminEditDetailTag = async (
+  subcategoryId: number,
+  tagId: number,
+  editDetailTagName: string
+) => {
+  try {
+    const response = await api.put(
+      `/admin/manage/subcategory/${subcategoryId}/tag/${tagId}/modify`,
+      {
+        name: editDetailTagName,
+      }
+    );
+    console.log("adminEditDetailTag", response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 상세항목 태그 삭제
+export const adminDeleteDetailTag = async (
+  subcategoryId: number,
+  tagId: number
+) => {
+  try {
+    const response = await api.delete(
+      `/admin/manage/subcategory/${subcategoryId}/tag/${tagId}/delete`
+    );
+    console.log("adminDeleteDetailTag", response);
+    if (response.status === 204) {
+      alert("상세항목 태그 삭제가 완료되었습니다");
+    }
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/adminSubCategory.ts
+++ b/src/api/adminSubCategory.ts
@@ -1,0 +1,52 @@
+import { api } from "./api";
+
+// 관리자 서브카테고리 생성
+export const adminAddNewSubCategory = async (
+  categoryId: number,
+  newName: string
+) => {
+  try {
+    const response = await api.post(
+      `/admin/manage/subcategory/${categoryId}/create`,
+      { name: newName }
+    );
+    console.log("adminAddNewSubCategory", response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 서브카테고리 수정
+export const adminEditSubCategory = async (
+  subcategoryId: number,
+  editSubCateName: string
+) => {
+  try {
+    const response = await api.put(
+      `/admin/manage/subcategory/${subcategoryId}/modify`,
+      { name: editSubCateName }
+    );
+    console.log("adminEditSubCategory", response);
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 관리자 서브카테고리 삭제
+export const adminDeleteSubCategory = async (subcategoryId: number) => {
+  try {
+    const response = await api.delete(
+      `/admin/manage/subcategory/${subcategoryId}/delete`
+    );
+    console.log("adminDeleteSubCategory", response);
+    if (response.status === 204) {
+      alert("서브카테고리 삭제가 완료되었습니다");
+    }
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/components/Admin/Button/AdminDeleteBtn.tsx
+++ b/src/components/Admin/Button/AdminDeleteBtn.tsx
@@ -5,7 +5,7 @@ interface AdminDeleteBtnProps {
 const AdminDeleteBtn = ({ onClick }: AdminDeleteBtnProps) => {
   return (
     <button onClick={onClick} className="cursor-pointer">
-      <img src={DeleteIcon} alt="계정 삭제 버튼" />
+      <img src={DeleteIcon} alt="삭제 버튼" />
     </button>
   );
 };

--- a/src/components/Admin/Button/AdminEditCancelBtn.tsx
+++ b/src/components/Admin/Button/AdminEditCancelBtn.tsx
@@ -1,12 +1,18 @@
+import { twMerge } from "tailwind-merge";
+
 interface AdminEditCancelBtnProps {
-  onClick: () => void;
+  onClick: (e?: any) => void;
+  css?: string;
 }
 
-const AdminEditCancelBtn = ({ onClick }: AdminEditCancelBtnProps) => {
+const AdminEditCancelBtn = ({ onClick, css }: AdminEditCancelBtnProps) => {
   return (
     <button
-      className="w-[37px] h-[24px] border rounded-[5px] outline-none
-  text-header-green border-header-green cursor-pointer"
+      className={twMerge(
+        `w-[37px] h-[24px] border rounded-[5px] outline-none
+  text-header-green border-header-green cursor-pointer`,
+        css
+      )}
       onClick={onClick}
     >
       취소

--- a/src/components/Admin/Tag/AdminTag.tsx
+++ b/src/components/Admin/Tag/AdminTag.tsx
@@ -24,8 +24,9 @@ const AdminTag = () => {
   const [subCategoryId, setSubCategoryId] = useState<number>();
 
   useEffect(() => {
-    if (allCategories) {
-      // setSubCategories2(allCategories[0].subcategories);
+    if (allCategories && isCategoryClicked) {
+      console.log("allCategories");
+      setSubCategories2(allCategories[isCategoryClicked].subcategories);
     }
   }, [allCategories]);
 
@@ -52,8 +53,6 @@ const AdminTag = () => {
 
     setIsAddDetailTag(false);
   };
-
-  // ---------------------------------------------------------------------------------
 
   const [isTagList, setIsTagList] = useState("tagList");
 
@@ -96,7 +95,7 @@ const AdminTag = () => {
     }) => adminAddNewSubCategory(categoryId, newSubCategoryName),
     onSuccess: () => {
       setIsAddSubCategory(false);
-      refetch();
+      // refetch();
     },
   });
 
@@ -211,11 +210,11 @@ const AdminTag = () => {
                   index={index}
                   id={subcategory.id}
                   name={subcategory.name}
-                  // onChange={handleSubcategoryChange}
                   onClick={subCategoryClick}
                   type="subCategory"
                   isClicked={isSubCateClicked}
                   setIsClicked={setIsSubCateClicked}
+                  setDetails2={setDetails2}
                 />
               ))}
               {isAddSubCategory && subCategories2 && (
@@ -267,11 +266,9 @@ const AdminTag = () => {
                   id={detail.id}
                   name={detail.name}
                   subcategoryId={subCategoryId}
-                  // onChange={handleDetailChange}
                   onClick={() => {}}
                   type="detailTags"
-                  // isClicked={isDetailTagClicked}
-                  // setIsClicked={setIsDetailTagClicked}
+                  setDetails2={setDetails2}
                 />
               ))}
               {isAddDetailTag && subCategoryId && (

--- a/src/components/Admin/Tag/AdminTag.tsx
+++ b/src/components/Admin/Tag/AdminTag.tsx
@@ -1,168 +1,63 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AdminButton from "../../common/AdminButton";
 import AddButton from "../../../assets/button/add_tag.svg";
 import AdminTagList from "./AdminTagList";
 import AdminTagAdd from "./AdminTagAdd";
-
-//랜덤id 생성함수
-const generateId = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
-
-// (임시) 카테고리 데이터
-const initialCategories = [
-  {
-    id: generateId(),
-    name: "개발",
-    value: 10,
-    subcategories: [
-      {
-        id: generateId(),
-        subname: "사용언어",
-        isEditable: false,
-        value: 10,
-        data: [
-          { id: generateId(), text: "C", value: 10 },
-          { id: generateId(), text: "C++", value: 20 },
-          { id: generateId(), text: "C#", value: 30 },
-          { id: generateId(), text: "Java", value: 40 },
-          {
-            id: generateId(),
-            text: "JavaScript",
-            value: 50,
-          },
-          {
-            id: generateId(),
-            text: "TypeScript",
-            value: 60,
-            isEditable: false,
-          },
-          { id: generateId(), text: "Python", value: 70, isEditable: false },
-          { id: generateId(), text: "Go", value: 80, isEditable: false },
-          { id: generateId(), text: "PHP", value: 90, isEditable: false },
-          { id: generateId(), text: "Swift", value: 100, isEditable: false },
-          { id: generateId(), text: "Kotlin", value: 110, isEditable: false },
-          { id: generateId(), text: "기타", value: 120, isEditable: false },
-        ],
-      },
-      {
-        id: generateId(),
-        subname: "프레임워크/라이브러리",
-        isEditable: false,
-        value: 10,
-        data: [
-          { id: generateId(), text: "Spring", value: 10, isEditable: false },
-          { id: generateId(), text: "React", value: 20, isEditable: false },
-          { id: generateId(), text: "Vue.js", value: 30, isEditable: false },
-          { id: generateId(), text: "Svelte", value: 40, isEditable: false },
-          { id: generateId(), text: "Angular", value: 50, isEditable: false },
-          { id: generateId(), text: "Flutter", value: 60, isEditable: false },
-          { id: generateId(), text: "Next.js", value: 70, isEditable: false },
-          { id: generateId(), text: "Nuxt.js", value: 80, isEditable: false },
-          { id: generateId(), text: "Unity", value: 90, isEditable: false },
-          { id: generateId(), text: "Unreal", value: 100, isEditable: false },
-          { id: generateId(), text: "Django", value: 110, isEditable: false },
-          { id: generateId(), text: "Flask", value: 120, isEditable: false },
-          {
-            id: generateId(),
-            text: "Bootstrap",
-            value: 130,
-            isEditable: false,
-          },
-          {
-            id: generateId(),
-            text: "Tailwind CSS",
-            value: 140,
-            isEditable: false,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    id: generateId(),
-    name: "교육",
-    isEditable: false,
-    value: 10,
-    subcategories: [
-      {
-        id: generateId(),
-        subname: "사용언어",
-        isEditable: false,
-        value: 10,
-        data: [
-          { id: generateId(), text: "C", value: 10, isEditable: false },
-          { id: generateId(), text: "C++", value: 20, isEditable: false },
-          { id: generateId(), text: "C#", value: 30, isEditable: false },
-          { id: generateId(), text: "Java", value: 40, isEditable: false },
-          {
-            id: generateId(),
-            text: "JavaScript",
-            value: 50,
-            isEditable: false,
-          },
-          {
-            id: generateId(),
-            text: "TypeScript",
-            value: 60,
-            isEditable: false,
-          },
-          { id: generateId(), text: "Python", value: 70, isEditable: false },
-          { id: generateId(), text: "Go", value: 80, isEditable: false },
-          { id: generateId(), text: "PHP", value: 90, isEditable: false },
-          { id: generateId(), text: "Swift", value: 100, isEditable: false },
-          { id: generateId(), text: "Kotlin", value: 110, isEditable: false },
-          { id: generateId(), text: "기타", value: 120, isEditable: false },
-        ],
-      },
-      {
-        id: generateId(),
-        subname: "프레임워크/라이브러리",
-        isEditable: false,
-        value: 10,
-        data: [
-          { id: generateId(), text: "Spring", value: 10, isEditable: false },
-          { id: generateId(), text: "React", value: 20, isEditable: false },
-          { id: generateId(), text: "Vue.js", value: 30, isEditable: false },
-          { id: generateId(), text: "Svelte", value: 40, isEditable: false },
-          { id: generateId(), text: "Angular", value: 50, isEditable: false },
-          { id: generateId(), text: "Flutter", value: 60, isEditable: false },
-          { id: generateId(), text: "Next.js", value: 70, isEditable: false },
-          { id: generateId(), text: "Nuxt.js", value: 80, isEditable: false },
-          { id: generateId(), text: "Unity", value: 90, isEditable: false },
-          { id: generateId(), text: "Unreal", value: 100, isEditable: false },
-          { id: generateId(), text: "Django", value: 110, isEditable: false },
-          { id: generateId(), text: "Flask", value: 120, isEditable: false },
-          {
-            id: generateId(),
-            text: "Bootstrap",
-            value: 130,
-            isEditable: false,
-          },
-          {
-            id: generateId(),
-            text: "Tailwind CSS",
-            value: 140,
-            isEditable: false,
-          },
-        ],
-      },
-    ],
-  },
-];
+import { useMutation, useMutationState, useQuery } from "@tanstack/react-query";
+import { adminNewCategory, getAllCategory } from "../../../api/adminCategory";
+import AdminTagBox from "./AdminTagBox";
+import { adminAddNewSubCategory } from "../../../api/adminSubCategory";
 
 const AdminTag = () => {
+  const {
+    data: allCategories,
+    isLoading,
+    refetch,
+  } = useQuery<AllCategoryType[]>({
+    queryKey: ["AllCategory"],
+    queryFn: getAllCategory,
+  });
+
+  const [subCategories2, setSubCategories2] = useState<SubCategoryType[]>([]);
+
+  const [details2, setDetails2] = useState<any[]>([]);
+
+  const [categoryId, setCategoryId] = useState<number>();
+
+  useEffect(() => {
+    if (allCategories) {
+      setSubCategories2(allCategories[0].subcategories);
+    }
+  }, [allCategories]);
+
+  const categoryClick = (categoryIndex: number, categoryId: number) => {
+    if (allCategories)
+      setSubCategories2(allCategories[categoryIndex].subcategories);
+    setDetails2([]);
+    setCategoryId(categoryId);
+  };
+
+  const subCategoryClick = (subCateIndex: number) => {
+    if (subCategories2) {
+      setDetails2(subCategories2[subCateIndex].tags);
+    }
+  };
+
+  // ---------------------------------------------------------------------------------
+
   const [isTagList, setIsTagList] = useState("tagList");
 
   const handleButtonClick = (type: "tagList" | "tagData") => {
     setIsTagList(type);
   };
 
-  const [categories, setCategories] = useState(initialCategories);
-  const [subcategories, setSubcategories] = useState(
-    initialCategories[0].subcategories
-  );
-  const [details, setDetails] = useState(
-    initialCategories[0].subcategories[0].data
-  );
+  // const [categories, setCategories] = useState(initialCategories);
+  // const [subcategories, setSubcategories] = useState(
+  //   initialCategories[0].subcategories
+  // );
+  // const [details, setDetails] = useState(
+  //   initialCategories[0].subcategories[0].data
+  // );
 
   const [addCategories, setAddCategories] = useState<
     | {
@@ -176,59 +71,69 @@ const AdminTag = () => {
   >(null);
 
   //  분야 추가
-  const handleAddCategory = () => {
-    setAddCategories([
-      {
-        id: generateId(),
-        name: "",
-        value: 10,
-        subcategories: [],
-        isEditable: true,
-      },
-    ]);
-  };
+  const [isAddCategory, setIsAddCategory] = useState(false);
 
-  //  분야 수정
-  const handleCategoryChange = (id: string, newName: string) => {
-    setCategories(
-      categories.map((category) =>
-        category.id === id ? { ...category, name: newName } : category
-      )
-    );
+  const { mutate: addNewCategoryFn } = useMutation({
+    mutationFn: (newCategoryName: string) => adminNewCategory(newCategoryName),
+    onSuccess: () => {
+      setIsAddCategory(false);
+      refetch();
+    },
+  });
+
+  const handleAddCategory = () => {
+    setIsAddCategory(true);
   };
 
   // 세부항목 추가
+  const [isAddSubCategory, setIsAddSubCategory] = useState(false);
+
   const handleAddSubcategory = () => {
-    setSubcategories([
-      ...subcategories,
-      { id: generateId(), subname: "", value: 10, data: [], isEditable: true },
-    ]);
+    if (subCategories2.length === 2) {
+      return alert("세부항목은 최대 2개까지 생성이 가능합니다");
+    }
+    setIsAddSubCategory(true);
   };
+
+  const { mutate: addNewSubCategory } = useMutation({
+    mutationFn: ({
+      categoryId,
+      newSubCategoryName,
+    }: {
+      categoryId: number;
+      newSubCategoryName: string;
+    }) => adminAddNewSubCategory(categoryId, newSubCategoryName),
+    onSuccess: () => {
+      setIsAddSubCategory(false);
+      refetch();
+    },
+  });
 
   // 세부항목 수정
   const handleSubcategoryChange = (id: string, newName: string) => {
-    setSubcategories(
-      subcategories.map((sub) =>
-        sub.id === id ? { ...sub, subname: newName } : sub
-      )
-    );
+    // setSubcategories(
+    //   subcategories.map((sub) =>
+    //     sub.id === id ? { ...sub, subname: newName } : sub
+    //   )
+    // );
   };
 
   // 상세항목 추가
+
   const handleAddDetail = () => {
-    setDetails([
-      ...details,
-      { id: generateId(), text: "", value: 10, isEditable: true },
-    ]);
+    // setDetails([
+    //   ...details,
+    //   { id: generateId(), text: "", value: 10, isEditable: true },
+    // ]);
   };
 
   // 상세항목 수정
   const handleDetailChange = (id: string, newText: string) => {
-    setDetails(
-      details.map((detail) =>
-        detail.id === id ? { ...detail, text: newText } : detail
-      )
-    );
+    // setDetails(
+    //   details.map((detail) =>
+    //     detail.id === id ? { ...detail, text: newText } : detail
+    //   )
+    // );
   };
 
   return (
@@ -257,35 +162,24 @@ const AdminTag = () => {
           <div className="flex flex-col w-full gap-[10px]">
             <span className="font-bold text-[16px] text-main-green">분야</span>
             <div className="flex w-full justify-end">
-              <button onClick={handleAddCategory}>
+              <button onClick={handleAddCategory} className="cursor-pointer">
                 <img src={AddButton} alt="분야 생성 버튼" />
               </button>
             </div>
-            <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
-              <div className="flex justify-center">
-                <span>No.</span>
-              </div>
-              <div className="flex justify-center">
-                <span>분야</span>
-              </div>
-              <div className="flex justify-center">
-                <span>수정</span>
-              </div>
-              <div className="flex justify-center">
-                <span>삭제</span>
-              </div>
-            </div>
+            <AdminTagBox name="분야" />
             <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {categories.map((category, index) => (
+              {allCategories?.map((category, index) => (
                 <AdminTagList
                   key={category.id}
                   index={index}
                   id={category.id}
                   name={category.name}
-                  onChange={handleCategoryChange}
+                  // onChange={handleCategoryChange}
+                  onClick={categoryClick}
+                  type="category"
                 />
               ))}
-              {addCategories?.map((category, index) => (
+              {/* {addCategories?.map((category, index) => (
                 <AdminTagAdd
                   key={category.id}
                   index={index + categories.length}
@@ -293,53 +187,69 @@ const AdminTag = () => {
                   name={category.name}
                   onChange={handleCategoryChange}
                 />
-              ))}
+              ))} */}
+              {isAddCategory && allCategories && (
+                <AdminTagAdd
+                  index={allCategories.length}
+                  onClick={(newCategoryName: string) =>
+                    addNewCategoryFn(newCategoryName)
+                  }
+                  setIsAdd={setIsAddCategory}
+                  addType="category"
+                />
+              )}
             </div>
           </div>
           <div className="flex flex-col w-full gap-[10px]">
             <span className="font-bold text-[16px] text-main-green">
               세부항목
             </span>
+
             <div className="flex w-full justify-end">
-              <button onClick={handleAddSubcategory}>
+              <button onClick={handleAddSubcategory} className="cursor-pointer">
                 <img src={AddButton} alt="세부항목 생성 버튼" />
               </button>
             </div>
-            <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
-              <div className="flex justify-center">
-                <span>No.</span>
-              </div>
-              <div className="flex justify-center">
-                <span>세부항목</span>
-              </div>
-              <div className="flex justify-center">
-                <span>수정</span>
-              </div>
-              <div className="flex justify-center">
-                <span>삭제</span>
-              </div>
-            </div>
+
+            <AdminTagBox name="세부항목" />
             <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {subcategories.map((subcategory, index) => (
+              {subCategories2.map((subcategory, index) => (
                 <AdminTagList
                   key={subcategory.id}
                   index={index}
                   id={subcategory.id}
-                  name={subcategory.subname}
-                  onChange={handleSubcategoryChange}
+                  name={subcategory.name}
+                  // onChange={handleSubcategoryChange}
+                  onClick={subCategoryClick}
+                  type="subCategory"
                 />
               ))}
+              {isAddSubCategory && subCategories2 && (
+                <AdminTagAdd
+                  index={subCategories2.length}
+                  categoryId={categoryId}
+                  addSubCategory={(
+                    categoryId: number,
+                    newSubCategoryName: string
+                  ) => addNewSubCategory({ categoryId, newSubCategoryName })}
+                  setIsAdd={setIsAddCategory}
+                  addType="subCategory"
+                />
+              )}
             </div>
           </div>
           <div className="flex flex-col w-full gap-[10px]">
             <span className="font-bold text-[16px] text-main-green">
               상세항목
             </span>
-            <div className="flex w-full justify-end">
-              <button onClick={handleAddDetail}>
-                <img src={AddButton} alt="상세항목 생성 버튼" />
-              </button>
-            </div>
+
+            <button
+              onClick={handleAddDetail}
+              className="flex w-full justify-end cursor-pointer"
+            >
+              <img src={AddButton} alt="상세항목 생성 버튼" />
+            </button>
+
             <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
               <div className="flex justify-center">
                 <span>No.</span>
@@ -355,13 +265,15 @@ const AdminTag = () => {
               </div>
             </div>
             <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {details.map((detail, index) => (
+              {details2.map((detail, index) => (
                 <AdminTagList
                   key={detail.id}
                   index={index}
                   id={detail.id}
-                  name={detail.text}
-                  onChange={handleDetailChange}
+                  name={detail.name}
+                  // onChange={handleDetailChange}
+                  onClick={() => {}}
+                  type="detailTags"
                 />
               ))}
             </div>

--- a/src/components/Admin/Tag/AdminTagAdd.tsx
+++ b/src/components/Admin/Tag/AdminTagAdd.tsx
@@ -1,61 +1,58 @@
-import EditButton from "../../../assets/icons/edit.svg";
-import DeleteButton from "../../../assets/icons/delete.svg";
 import SaveButton from "../../../assets/icons/save.svg";
 import { useState } from "react";
+import AdminEditCancelBtn from "../Button/AdminEditCancelBtn";
 
 interface AdminTagAddProps {
   index: number;
-  name: string;
-  id: string;
-  onChange: (id: string, newName: string) => void;
+  onClick?: (newCategoryName: string) => void;
+  categoryId?: number;
+  addSubCategory?: (categoryId: number, newSubCategoryName: string) => void;
+  setIsAdd: React.Dispatch<React.SetStateAction<boolean>>;
+  addType: string;
 }
 
-const AdminTagAdd = ({ index, name, id, onChange }: AdminTagAddProps) => {
-  const [isEditable, setIsEditable] = useState(true);
-  const [value, setValue] = useState(name);
-
-  const handleSave = () => {
-    onChange(id, value);
-    setIsEditable(false);
-  };
+const AdminTagAdd = ({
+  index,
+  setIsAdd,
+  categoryId,
+  onClick,
+  addSubCategory,
+  addType,
+}: AdminTagAddProps) => {
+  const [newValue, setNewValue] = useState("");
 
   return (
     <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green ">
-      <div className="flex justify-center">
+      <div className="flex justify-center items-center">
         <span>{index + 1}</span>
       </div>
-      <div className="flex w-full justify-center ">
-        {isEditable ? (
-          <input
-            type="text"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            maxLength={20}
-            className="resize-none text-[14px] h-[25px] w-full text-center focus:outline-none spellcheck-false overflow-hidden whitespace-nowrap text-ellipsis border-b border-b-header-green"
-          />
-        ) : (
-          <span className="text-[14px] text-center">{name}</span>
-        )}
+      <div className="flex w-full justify-center items-center">
+        <input
+          type="text"
+          value={newValue}
+          onChange={(e) => setNewValue(e.target.value)}
+          maxLength={20}
+          className="resize-none text-[14px] h-[25px] w-full text-center focus:outline-none spellcheck-false overflow-hidden whitespace-nowrap text-ellipsis border-b border-b-header-green"
+        />
       </div>
-      {!isEditable ? (
-        <button
-          className="flex justify-center cursor-pointer"
-          onClick={() => setIsEditable(true)}
-        >
-          <img src={EditButton} alt="수정 버튼" className="w-[25px] h-[25px]" />
-        </button>
-      ) : (
-        <button
-          className="flex justify-center cursor-pointer"
-          onClick={handleSave}
-        >
-          <img src={SaveButton} alt="저장 버튼" className="w-[25px] h-[25px]" />
-        </button>
-      )}
 
-      <button className="flex justify-center cursor-pointer">
-        <img src={DeleteButton} alt="삭제 버튼" className="w-[25px] h-[25px]" />
+      <button
+        className="flex justify-center items-center cursor-pointer"
+        onClick={() => {
+          if (addType === "category" && onClick) {
+            onClick(newValue);
+          } else if (
+            addType === "subCategory" &&
+            addSubCategory &&
+            categoryId
+          ) {
+            addSubCategory(categoryId, newValue);
+          }
+        }}
+      >
+        <img src={SaveButton} alt="저장 버튼" className="w-[35px] h-[35px]" />
       </button>
+      <AdminEditCancelBtn onClick={() => setIsAdd(false)} />
     </div>
   );
 };

--- a/src/components/Admin/Tag/AdminTagAdd.tsx
+++ b/src/components/Admin/Tag/AdminTagAdd.tsx
@@ -6,17 +6,21 @@ interface AdminTagAddProps {
   index: number;
   onClick?: (newCategoryName: string) => void;
   categoryId?: number;
+  subcategoryId?: number;
   addSubCategory?: (categoryId: number, newSubCategoryName: string) => void;
   setIsAdd: React.Dispatch<React.SetStateAction<boolean>>;
   addType: string;
+  addDetailTag?: (subcategoryId: number, newDetailTagName: string) => void;
 }
 
 const AdminTagAdd = ({
   index,
   setIsAdd,
   categoryId,
+  subcategoryId,
   onClick,
   addSubCategory,
+  addDetailTag,
   addType,
 }: AdminTagAddProps) => {
   const [newValue, setNewValue] = useState("");
@@ -40,19 +44,32 @@ const AdminTagAdd = ({
         className="flex justify-center items-center cursor-pointer"
         onClick={() => {
           if (addType === "category" && onClick) {
+            if (!newValue.trim().length) {
+              return alert("최소 한글자 이상 입력해주세요");
+            }
             onClick(newValue);
           } else if (
             addType === "subCategory" &&
             addSubCategory &&
             categoryId
           ) {
+            if (!newValue.trim().length) {
+              return alert("최소 한글자 이상 입력해주세요");
+            }
             addSubCategory(categoryId, newValue);
+          } else if (addType === "detailTag" && addDetailTag && subcategoryId) {
+            if (!newValue.trim().length) {
+              return alert("최소 한글자 이상 입력해주세요");
+            }
+            addDetailTag(subcategoryId, newValue);
           }
         }}
       >
         <img src={SaveButton} alt="저장 버튼" className="w-[35px] h-[35px]" />
       </button>
-      <AdminEditCancelBtn onClick={() => setIsAdd(false)} />
+      <div className="flex justify-center items-center">
+        <AdminEditCancelBtn onClick={() => setIsAdd(false)} />
+      </div>
     </div>
   );
 };

--- a/src/components/Admin/Tag/AdminTagBox.tsx
+++ b/src/components/Admin/Tag/AdminTagBox.tsx
@@ -1,0 +1,24 @@
+interface AdminTagBoxProps {
+  name: string;
+}
+
+const AdminTagBox = ({ name }: AdminTagBoxProps) => {
+  return (
+    <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
+      <div className="flex justify-center">
+        <span>No.</span>
+      </div>
+      <div className="flex justify-center">
+        <span>{name}</span>
+      </div>
+      <div className="flex justify-center">
+        <span>수정</span>
+      </div>
+      <div className="flex justify-center">
+        <span>삭제</span>
+      </div>
+    </div>
+  );
+};
+
+export default AdminTagBox;

--- a/src/components/Admin/Tag/AdminTagList.tsx
+++ b/src/components/Admin/Tag/AdminTagList.tsx
@@ -13,23 +13,36 @@ import {
   adminDeleteSubCategory,
   adminEditSubCategory,
 } from "../../../api/adminSubCategory";
+import {
+  adminDeleteDetailTag,
+  adminEditDetailTag,
+} from "../../../api/adminDetailTag";
+import { twMerge } from "tailwind-merge";
 
 interface AdminTagListProps {
   index: number;
   name: string;
   id: number;
+  subcategoryId?: number;
   // onChange: (id: number, newName: string) => void;
   onClick: (categoryIndex: number, categoryId: number) => void;
   type: "category" | "subCategory" | "detailTags";
+  isClicked?: number | null;
+  setIsClicked?: React.Dispatch<
+    React.SetStateAction<number | null | undefined>
+  >;
 }
 
 const AdminTagList = ({
   index,
   name,
   id,
+  subcategoryId,
   // onChange,
   onClick,
   type,
+  isClicked,
+  setIsClicked,
 }: AdminTagListProps) => {
   const [isEditable, setIsEditable] = useState(false);
   const [value, setValue] = useState(name);
@@ -54,14 +67,12 @@ const AdminTagList = ({
     onSettled: () => setIsEditable(false),
   });
 
-  const handleSave = () => {
-    editCategoryFn({ categoryId: id, editedName: value });
-  };
-
   // 서브카테고리 삭제함수
   const { mutate: deleteSubCategoryFn } = useMutation({
     mutationFn: (subcategoryId: number) =>
       adminDeleteSubCategory(subcategoryId),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
   });
 
   // 서브카테고리 수정함수
@@ -73,12 +84,52 @@ const AdminTagList = ({
       subcategoryId: number;
       editSubCateName: string;
     }) => adminEditSubCategory(subcategoryId, editSubCateName),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
+    onSettled: () => setIsEditable(false),
+  });
+
+  // 상세항목 태그 삭제함수
+  const { mutate: deleteDetailTagFn } = useMutation({
+    mutationFn: ({
+      subcategoryId,
+      tagId,
+    }: {
+      subcategoryId: number;
+      tagId: number;
+    }) => adminDeleteDetailTag(subcategoryId, tagId),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
+  });
+
+  // 상세항목 태그 수정함수
+  const { mutate: editDetailTagFn } = useMutation({
+    mutationFn: ({
+      subcategoryId,
+      tagId,
+      editDetailTagName,
+    }: {
+      subcategoryId: number;
+      tagId: number;
+      editDetailTagName: string;
+    }) => adminEditDetailTag(subcategoryId, tagId, editDetailTagName),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
   });
 
   return (
     <div
-      onClick={() => onClick(index, id)}
-      className="grid grid-cols-[9.4%_1fr_25%] w-full h-[33px] text-main-green cursor-pointer"
+      onClick={() => {
+        onClick(index, id);
+        if (setIsClicked) {
+          setIsClicked(index);
+        }
+      }}
+      className={twMerge(
+        `grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green cursor-pointer ${
+          isClicked === index ? "bg-main-green03" : ""
+        }`
+      )}
     >
       <div className="flex justify-center items-center">
         <span>{index + 1}</span>
@@ -97,9 +148,9 @@ const AdminTagList = ({
         )}
       </div>
       {!isEditable ? (
-        <div className="flex justify-center gap-5">
+        <>
           <button
-            className="flex  justify-center cursor-pointer"
+            className="flex justify-center cursor-pointer"
             onClick={() => {
               setIsEditable(true);
             }}
@@ -121,25 +172,39 @@ const AdminTagList = ({
                   deleteCategoryFn(id);
                 } else if (type === "subCategory") {
                   deleteSubCategoryFn(id);
+                } else if (type === "detailTags" && subcategoryId) {
+                  deleteDetailTagFn({ subcategoryId, tagId: id });
                 }
               }}
             />
           </button>
-        </div>
+        </>
       ) : (
-        <div
-          onClick={(e) => e.stopPropagation()}
-          className=" flex justify-center items-center gap-5"
-        >
+        <>
           <button
-            className="w-[35px] h-[35px] flex justify-center cursor-pointer"
+            className="flex justify-center cursor-pointer"
             onClick={() => {
               if (type === "category") {
+                if (!value.trim().length) {
+                  return alert("최소 한글자 이상 입력해주세요");
+                }
                 editCategoryFn({ categoryId: id, editedName: value });
               } else if (type === "subCategory") {
+                if (!value.trim().length) {
+                  return alert("최소 한글자 이상 입력해주세요");
+                }
                 editSubCategoryFn({
                   subcategoryId: id,
                   editSubCateName: value,
+                });
+              } else if (type === "detailTags" && subcategoryId) {
+                if (!value.trim().length) {
+                  return alert("최소 한글자 이상 입력해주세요");
+                }
+                editDetailTagFn({
+                  subcategoryId,
+                  tagId: id,
+                  editDetailTagName: value,
                 });
               }
             }}
@@ -151,11 +216,13 @@ const AdminTagList = ({
             />
           </button>
 
-          <AdminEditCancelBtn
-            onClick={() => setIsEditable(false)}
-            css={"w-[35px] text-[14px]"}
-          />
-        </div>
+          <div className="flex justify-center items-center">
+            <AdminEditCancelBtn
+              onClick={() => setIsEditable(false)}
+              css={"w-[35px] text-[14px]"}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/Admin/Tag/AdminTagList.tsx
+++ b/src/components/Admin/Tag/AdminTagList.tsx
@@ -2,29 +2,88 @@ import EditButton from "../../../assets/icons/edit.svg";
 import DeleteButton from "../../../assets/icons/delete.svg";
 import SaveButton from "../../../assets/icons/save.svg";
 import { useState } from "react";
+import AdminEditCancelBtn from "../Button/AdminEditCancelBtn";
+import { useMutation } from "@tanstack/react-query";
+import {
+  adminDeleteCategory,
+  adminEditCategory,
+} from "../../../api/adminCategory";
+import { queryClient } from "../../../main";
+import {
+  adminDeleteSubCategory,
+  adminEditSubCategory,
+} from "../../../api/adminSubCategory";
 
 interface AdminTagListProps {
   index: number;
   name: string;
-  id: string;
-  onChange: (id: string, newName: string) => void;
+  id: number;
+  // onChange: (id: number, newName: string) => void;
+  onClick: (categoryIndex: number, categoryId: number) => void;
+  type: "category" | "subCategory" | "detailTags";
 }
 
-const AdminTagList = ({ index, name, id, onChange }: AdminTagListProps) => {
+const AdminTagList = ({
+  index,
+  name,
+  id,
+  // onChange,
+  onClick,
+  type,
+}: AdminTagListProps) => {
   const [isEditable, setIsEditable] = useState(false);
   const [value, setValue] = useState(name);
 
+  // 카테고리 삭제함수
+  const { mutate: deleteCategoryFn } = useMutation({
+    mutationFn: (categoryId: number) => adminDeleteCategory(categoryId),
+    // onSuccess:
+  });
+
+  // 카테고리 수정함수
+  const { mutate: editCategoryFn } = useMutation({
+    mutationFn: ({
+      categoryId,
+      editedName,
+    }: {
+      categoryId: number;
+      editedName: string;
+    }) => adminEditCategory(categoryId, editedName),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
+    onSettled: () => setIsEditable(false),
+  });
+
   const handleSave = () => {
-    onChange(id, value);
-    setIsEditable(false);
+    editCategoryFn({ categoryId: id, editedName: value });
   };
 
+  // 서브카테고리 삭제함수
+  const { mutate: deleteSubCategoryFn } = useMutation({
+    mutationFn: (subcategoryId: number) =>
+      adminDeleteSubCategory(subcategoryId),
+  });
+
+  // 서브카테고리 수정함수
+  const { mutate: editSubCategoryFn } = useMutation({
+    mutationFn: ({
+      subcategoryId,
+      editSubCateName,
+    }: {
+      subcategoryId: number;
+      editSubCateName: string;
+    }) => adminEditSubCategory(subcategoryId, editSubCateName),
+  });
+
   return (
-    <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green ">
-      <div className="flex justify-center">
+    <div
+      onClick={() => onClick(index, id)}
+      className="grid grid-cols-[9.4%_1fr_25%] w-full h-[33px] text-main-green cursor-pointer"
+    >
+      <div className="flex justify-center items-center">
         <span>{index + 1}</span>
       </div>
-      <div className="flex w-full justify-center ">
+      <div className="flex w-full justify-center  items-center">
         {isEditable ? (
           <input
             type="text"
@@ -38,24 +97,66 @@ const AdminTagList = ({ index, name, id, onChange }: AdminTagListProps) => {
         )}
       </div>
       {!isEditable ? (
-        <button
-          className="flex justify-center cursor-pointer"
-          onClick={() => setIsEditable(true)}
-        >
-          <img src={EditButton} alt="수정 버튼" className="w-[25px] h-[25px]" />
-        </button>
+        <div className="flex justify-center gap-5">
+          <button
+            className="flex  justify-center cursor-pointer"
+            onClick={() => {
+              setIsEditable(true);
+            }}
+          >
+            <img
+              src={EditButton}
+              alt="수정 버튼"
+              className="w-[35px] h-[35px]"
+            />
+          </button>
+          <button className="flex justify-center cursor-pointer">
+            <img
+              src={DeleteButton}
+              alt="삭제 버튼"
+              className="w-[35px] h-[35px]"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (type === "category") {
+                  deleteCategoryFn(id);
+                } else if (type === "subCategory") {
+                  deleteSubCategoryFn(id);
+                }
+              }}
+            />
+          </button>
+        </div>
       ) : (
-        <button
-          className="flex justify-center cursor-pointer"
-          onClick={handleSave}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className=" flex justify-center items-center gap-5"
         >
-          <img src={SaveButton} alt="저장 버튼" className="w-[25px] h-[25px]" />
-        </button>
-      )}
+          <button
+            className="w-[35px] h-[35px] flex justify-center cursor-pointer"
+            onClick={() => {
+              if (type === "category") {
+                editCategoryFn({ categoryId: id, editedName: value });
+              } else if (type === "subCategory") {
+                editSubCategoryFn({
+                  subcategoryId: id,
+                  editSubCateName: value,
+                });
+              }
+            }}
+          >
+            <img
+              src={SaveButton}
+              alt="저장 버튼"
+              className="w-[35px] h-[35px]"
+            />
+          </button>
 
-      <button className="flex justify-center cursor-pointer">
-        <img src={DeleteButton} alt="삭제 버튼" className="w-[25px] h-[25px]" />
-      </button>
+          <AdminEditCancelBtn
+            onClick={() => setIsEditable(false)}
+            css={"w-[35px] text-[14px]"}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Admin/Tag/AdminTagList.tsx
+++ b/src/components/Admin/Tag/AdminTagList.tsx
@@ -24,7 +24,6 @@ interface AdminTagListProps {
   name: string;
   id: number;
   subcategoryId?: number;
-  // onChange: (id: number, newName: string) => void;
   onClick: (categoryIndex: number, categoryId: number) => void;
   type: "category" | "subCategory" | "detailTags";
   isClicked?: number | null;
@@ -38,7 +37,6 @@ const AdminTagList = ({
   name,
   id,
   subcategoryId,
-  // onChange,
   onClick,
   type,
   isClicked,
@@ -86,7 +84,6 @@ const AdminTagList = ({
     }) => adminEditSubCategory(subcategoryId, editSubCateName),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
-    onSettled: () => setIsEditable(false),
   });
 
   // 상세항목 태그 삭제함수

--- a/src/components/EditProjectModal/SelectCategory.tsx
+++ b/src/components/EditProjectModal/SelectCategory.tsx
@@ -3,7 +3,7 @@ import cancelButton from "../../assets/button/cancelButton.svg";
 import triangleUp from "../../assets/button/triangle/triangleUp.svg";
 import triangleDown from "../../assets/button/triangle/triangleDown.svg";
 import { useQuery } from "@tanstack/react-query";
-import { getAllCategory } from "../../api/admin";
+import { getAllCategory } from "../../api/adminCategory";
 
 // 선택된 데이터 타입
 interface SelectedDataType {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자페이지 태그부분 기능구현했습니다.
- 현재 세부항목(서브카테고리) 부분에서 이슈가 많아서 백엔드분들께 확인요청부탁드렸습니다.
- 서브카테고리 이슈사항

1. 삭제가 되는 것이 있고 안되는 것이 있음
2. 새로 생성시 response로 500에러가 뜨지만 추가는 정상적으로 됨 (새로고침 해야됩니다)
3. 수정 시 response로 정상적으로 응답값이 오는데 데이터베이스에 수정된 서브카테고리 반영이 안됩니다.


- 분야 선택 -> 세부항목(서브카테고리) 선택 -> 상세항목 순으로 클릭해야 항목들이 보입니다.
- 각 항목 수정/추가할 때 빈 문자열일 경우 경고창 띄웁니다.
- admin 태그 부분과 관련된 api가 너무 많아서 분야, 세부항목, 상세항목 형식으로 파일 분리했습니다.


## 🔗 관련 이슈

#179 

## 📸 스크린샷 (선택)
<img width="1914" alt="스크린샷 2025-03-05 오후 2 38 21" src="https://github.com/user-attachments/assets/070e340f-76a1-43d9-9c47-b91ea35aa824" />

<img width="1933" alt="스크린샷 2025-03-05 오후 2 38 33" src="https://github.com/user-attachments/assets/ae6f31d5-cdd9-4780-93b4-f0036957df10" />

<img width="634" alt="스크린샷 2025-03-05 오후 2 38 50" src="https://github.com/user-attachments/assets/b778e9d1-c15d-4839-82e8-16299746a136" />

<img width="1352" alt="스크린샷 2025-03-05 오후 2 39 11" src="https://github.com/user-attachments/assets/f4b0a52e-f325-47c7-9cd6-476eda528afe" />
