### PR TITLE
Fix 캘린더 프로젝트개인업무 버튼 #196

### DIFF
--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -19,20 +19,25 @@ const Calendar = () => {
   // 프로젝트 및 업무 토글 상태
   const [showTasks, setShowTasks] = useState(false);
 
-  useEffect(() => {
-    const projectButton = document.querySelector(".fc-project-button");
-    const taskButton = document.querySelector(".fc-task-button");
+  const PROJECT_BUTTON = {
+    text: "프로젝트",
+    click: () => setShowTasks(false), // 프로젝트 데이터 표시
+  };
 
-    if (projectButton && taskButton) {
-      if (showTasks) {
-        projectButton.classList.remove("fc-active");
-        taskButton.classList.add("fc-active");
-      } else {
-        projectButton.classList.add("fc-active");
-        taskButton.classList.remove("fc-active");
-      }
-    }
-  }, [showTasks]);
+  const PROJECT_CLICK_BUTTON = {
+    text: "프로젝트",
+    click: () => setShowTasks(false), // 프로젝트 데이터 표시
+  };
+
+  const TASK_BUTTON = {
+    text: "개인업무",
+    click: () => setShowTasks(true), // 개인업무 데이터 표시
+  };
+
+  const TASK_CLICK_BUTTON = {
+    text: "개인업무",
+    click: () => setShowTasks(true), // 개인업무 데이터 표시
+  };
 
   const navigate = useNavigate();
   const loginUser = useAuthStore((state) => state.member);
@@ -146,14 +151,10 @@ const Calendar = () => {
       <FullCalendar
         plugins={[dayGridPlugin, interactionPlugin]}
         customButtons={{
-          project: {
-            text: "프로젝트",
-            click: () => setShowTasks(false),
-          },
-          task: {
-            text: "개인업무",
-            click: () => setShowTasks(true),
-          },
+          project: PROJECT_BUTTON,
+          projectclick: PROJECT_CLICK_BUTTON,
+          task: TASK_BUTTON,
+          taskclick: TASK_CLICK_BUTTON,
         }}
         initialView="dayGridMonth"
         height="100%"
@@ -161,7 +162,9 @@ const Calendar = () => {
         headerToolbar={{
           left: "prev title next",
           center: "",
-          right: "project task",
+          right: `${showTasks ? "project" : "projectclick"} ${
+            showTasks ? "taskclick" : "task"
+          }`,
         }}
         // 한국어
         locale={koLocale}

--- a/src/components/MainPage/ScheduleBox.tsx
+++ b/src/components/MainPage/ScheduleBox.tsx
@@ -1,20 +1,75 @@
+import { useQuery } from "@tanstack/react-query";
 import { twMerge } from "tailwind-merge";
+import { getProjectById } from "../../api/project";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import dayjs from "dayjs";
 
 interface ScheduleBoxProps {
-  endTime: string; // 마감시간
-  remainingTime: string; // 남은 시간
-  scheduleName: string;
-  projectName: string;
-  isDeadline?: boolean; // 마감시간 임박 시 true
+  task: GetAssignedTask;
+  currentTime: string;
 }
 
-const ScheduleBox = ({
-  endTime,
-  remainingTime,
-  scheduleName,
-  projectName,
-  isDeadline = false,
-}: ScheduleBoxProps) => {
+const ScheduleBox = ({ task, currentTime }: ScheduleBoxProps) => {
+  const navigate = useNavigate();
+  const [isDeadline, setIsDeadline] = useState<boolean>(false);
+  const [remainingTime, setRemainingTime] = useState<string>("");
+
+  // 마감 시간 포맷
+  const endTime = task.endDate
+    .split("T")
+    .pop()
+    ?.split(":")
+    .slice(0, 2)
+    .join(":");
+
+  // 현재 시간에 현재 날짜를 결합하여 dayjs에서 인식할 수 있는 형식으로 변환
+  const now = dayjs();
+  const fullCurrentTime = now.format("YYYY-MM-DD") + "T" + currentTime;
+
+  // 남은 시간 계산
+  useEffect(() => {
+    const calculateRemainingTime = () => {
+      const currentDayjs = dayjs(fullCurrentTime); // currentTime을 fullCurrentTime으로 변환
+      const end = dayjs(task.endDate);
+      const diff = end.diff(currentDayjs);
+
+      // 남은 시간이 1시간 이내라면 데드라인 상태로 변경
+      setIsDeadline(diff > 0 && diff < 1000 * 60 * 60);
+
+      if (diff <= 0) {
+        setRemainingTime("마감됨");
+        return;
+      }
+
+      const hours = Math.floor(diff / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60 * 60));
+
+      if (hours > 0) {
+        setRemainingTime(`${hours}시간 ${minutes}분 남음`);
+      } else if (minutes > 0) {
+        setRemainingTime(`${minutes}분 남음`);
+      } else {
+        setRemainingTime(`${seconds}초 남음`);
+      }
+    };
+
+    calculateRemainingTime(); // currentTime이 변경될 때마다 실행
+  }, [fullCurrentTime, task.endDate]);
+
+  // 프로젝트 정보 불러오기
+  const { data: projectDetail } = useQuery<ProjectDetailType>({
+    queryKey: ["ProjectDetail"],
+    queryFn: async () => {
+      const response = await getProjectById(String(task.projectId));
+      return response;
+    },
+  });
+
+  // 프로젝트명
+  const projectName = projectDetail?.name;
+
   return (
     <div
       className={twMerge(
@@ -22,20 +77,21 @@ const ScheduleBox = ({
           items-center px-3 pb-2 bg-main-green02 cursor-pointer rounded-[10px]
           ${isDeadline && "bg-[#FF6854] text-white"}`
       )}
+      onClick={() => navigate(`/project-room/${task.projectId}`)}
     >
       {/* 마감시간, 남은시간 */}
       <div>
         <div className="flex items-center gap-4 text-[30px] ">
-          <p>{endTime}</p>
+          <p className="w-[100px] text-center">{endTime}</p>
 
-          <p className="text-[14px]">{remainingTime} 남음</p>
+          <p className="w-[120px] text-[14px]">{remainingTime}</p>
         </div>
       </div>
 
       {/* 업무명, 프로젝트 명 */}
       <div className="w-full py-1 px-2 shadow-2xl bg-white/25 rounded-[5px]">
-        <p className="font-bold">{scheduleName}</p>
-        <p>{projectName}</p>
+        <p className="font-bold">{task.title}</p>
+        <p className="font-extralight">{projectName}</p>
       </div>
     </div>
   );

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -19,8 +19,8 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
 
   // console.log(updatedData);
   // console.log(task);
-  console.log(updatedData);
-  console.log(task);
+  // console.log(updatedData);
+  // console.log(task);
 
   /* 시작버튼 클릭 -> 진행 중 상태 변경 함수 */
   const handleStateStart = () => {
@@ -70,8 +70,10 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
         {/* 기간, 업무완료,시잔 버튼 */}
         <div className="flex justify-between items-center">
           <p className="text-[12px]">
-            {updatedData.startDate.split("T")[0]} ~{" "}
-            {updatedData.endDate.split("T")[0]}
+            {updatedData &&
+              `${updatedData.startDate.split("T")[0]} ~ ${
+                updatedData.endDate.split("T")[0]
+              }`}
           </p>
           {task.assignedMemberName === member?.username &&
             (task.status !== "IN_PROGRESS" ? (
@@ -142,7 +144,8 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
         {/* 기간, 업무 완료/시작 버튼 */}
         <div className="flex justify-between items-center">
           <p className="text-[12px]">
-            {task.startDate.split("T")} ~ {task.endDate.split("T")}
+            {task.startDate.split("T").slice(0, 1)} ~{" "}
+            {task.endDate.split("T").slice(0, 1)}
           </p>
           {task.assignedMemberName === member?.username &&
             (task.status !== "IN_PROGRESS" ? (

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -32,6 +32,7 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
   });
 
   const handleUpdateTask = async (taskId: number, updateData: UpdateTask) => {
+    console.log("업데이트 데이터:", taskId, updateData);
     try {
       await updateMutation.mutateAsync({ taskId, updateData });
       console.log("업무 수정 완료:", taskId, updateData);

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -20,7 +20,7 @@ const ConfirmModal = ({
   onDeleteTask?: () => void;
   deleteOrLeave?: () => void;
 }) => {
-  const { logout } = useAuthStore();
+  const logout = useAuthStore((state) => state.logout);
 
   // 모달 적용
   const [modalText, setModalText] = useState<string>("");

--- a/src/components/modals/UpdateTaskModal.tsx
+++ b/src/components/modals/UpdateTaskModal.tsx
@@ -6,6 +6,8 @@ import WriteProjectName from "../EditProjectModal/WriteProjectName";
 import ConfirmModal from "./ConfirmModal";
 import { getTaskById } from "../../api/task";
 import { useQuery } from "@tanstack/react-query";
+import defaultImg from "../../assets/defaultImg.svg";
+import { useAuthStore } from "../../store/authStore";
 
 const UpdateTaskModal = ({
   task,
@@ -16,6 +18,7 @@ const UpdateTaskModal = ({
   refetch,
 }: UpdateTaskModalProps) => {
   const [isConfirmModal, setIsConfirmModal] = useState<boolean>(false);
+  const loginUser = useAuthStore((state) => state.member);
 
   //selectedStartDate, selectedEndDate에 데이터 들어갈 수 있게 분리하는 함수
   const parseDateTime = (dateTimeString: string) => {
@@ -64,7 +67,7 @@ const UpdateTaskModal = ({
     HOLD: "보류",
   };
 
-  // 업무 정보 불러오기
+  /* 업무 정보 불러오기 */
   const { data: updatedData } = useQuery<GetUpdateTask>({
     queryKey: ["UpdatedData", task.taskId],
     queryFn: async () => {
@@ -86,9 +89,9 @@ const UpdateTaskModal = ({
   const [memberData, setMemberData] = useState<MemberType[]>([
     {
       username: task.assignedMemberName,
-      profile: updatedData?.participantProfiles[0] || "",
+      profile: updatedData?.participantProfiles?.[0] ?? defaultImg,
       email: "",
-      memberId: updatedData?.participantIds[0] || 0,
+      memberId: updatedData?.participantIds?.[0] ?? 0,
     },
   ]);
 
@@ -109,12 +112,20 @@ const UpdateTaskModal = ({
     startDate: formatDateTime(selectedStartDate),
     endDate: formatDateTime(selectedEndDate),
     status: reversedStatusOptions[selectedStatus],
-    assignedMemberId: memberData[0].memberId,
-    participantIds: [memberData[0].memberId],
+    assignedMemberId:
+      memberData && memberData[0]?.memberId
+        ? memberData[0]?.memberId
+        : updatedData?.assignedMemberId || loginUser?.id || 0,
+    participantIds:
+      memberData && memberData[0]?.memberId
+        ? [memberData[0]?.memberId]
+        : updatedData?.assignedMemberId
+        ? [updatedData?.assignedMemberId]
+        : [loginUser?.id || 0], // 참여자 배열이 비어있으면 빈 배열을 할당
   };
 
   // console.log(task);
-  // console.log(updatedData, isLoading);
+  // console.log(updatedData);
   // console.log(taskInfo);
 
   return (

--- a/src/styles/Calandar.css
+++ b/src/styles/Calandar.css
@@ -24,8 +24,8 @@
 }
 
 /* 커스텀 프로젝트 버튼 */
-.fc-project-button.fc-active,
-.fc-task-button.fc-active {
+.fc-projectclick-button,
+.fc-taskclick-button {
   width: 70px !important;
   height: 30px !important;
   font-size: 14px !important;


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 메인페이지 프로젝트/개인업무 버튼 클릭 시 활성/비활성화 스타일 적용했습니다.
- 메인페이지 개인업무 리스트에 데이터 적용했습니다 (추가 수정 중)
- 업무박스에서 기간 오류 및 편집모달에서의 오류 해결했습니다.

## 🔗 관련 이슈

- 관련된 이슈 번호를 적어주세요. (예: `#3`)

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/9478a295-8cca-4df9-9e0f-c9352e2674e4)
