### PR TITLE
Fix 프로젝트 생성모달 날짜제한 수정 #198

### DIFF
--- a/src/components/EditProjectModal/DateTimeSelect.tsx
+++ b/src/components/EditProjectModal/DateTimeSelect.tsx
@@ -121,7 +121,6 @@ const DateTimeSelect = ({
               text-[14px] font-bold text-main-green bg-gradient-to-t from-[#E1E6E2] to-white/40 cursor-pointer"
               onClick={() => toggleDropdown("year")}
             >
-              {/* {selectedDate?.year || now.getFullYear()} */}
               {selectedDate?.year}
             </div>
 
@@ -144,8 +143,6 @@ const DateTimeSelect = ({
               text-[14px] font-bold text-main-green bg-gradient-to-t from-[#E1E6E2] to-white/40 cursor-pointer"
               onClick={() => toggleDropdown("month")}
             >
-              {/* {selectedDate?.month ||
-                String(now.getMonth() + 1).padStart(2, "0")} */}
               {selectedDate?.month}
             </div>
             {openDropdown === "month" && (
@@ -234,9 +231,6 @@ const DateTimeSelect = ({
               text-[14px] font-bold text-main-green bg-gradient-to-t from-[#E1E6E2] to-white/40 cursor-pointer"
               onClick={() => toggleDropdown("hour")}
             >
-              {/* {selectedDate?.hour || title === "시작"
-                ? String(nowHours12).padStart(2, "0")
-                : String(nowHours12 + 1).padStart(2, "0")} */}
               {selectedDate?.hour}
             </div>
             {openDropdown === "hour" && (

--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -377,7 +377,7 @@ const EditProjectModal = ({
                     if (newProjectInfo.startDate > newProjectInfo.endDate) {
                       return setEndDateAlertModalOpen(true);
                     }
-                    // newProjectPost(newProjectInfo);
+                    newProjectPost(newProjectInfo);
                   }}
                 />
               )}

--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -370,7 +370,7 @@ const EditProjectModal = ({
                     setPages(1);
                     if (
                       newProjectInfo.startDate <
-                      dayjs().format("YYYY-MM-DDTHH:mm:ss")
+                      dayjs().subtract(1, "day").format("YYYY-MM-DDTHH:mm:ss")
                     ) {
                       return setStartDateAlertMadalOpen(true);
                     }
@@ -442,7 +442,7 @@ const EditProjectModal = ({
       {startDateAlertMadalOpen && (
         <div className="absolute top-[50px] z-20 bg-black/50 h-[calc(100vh-50px)] w-full flex items-center justify-center">
           <SimpleAlertModal
-            text="시작 날짜는 현재 또는 미래여야 합니다"
+            text="시작 날짜는 1일 전부터 설정이 가능합니다."
             setIsModal={setStartDateAlertMadalOpen}
           />
         </div>

--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -13,6 +13,7 @@ import { patchProjectById, postProject } from "../../api/project";
 import { useNavigate } from "react-router";
 import { progressType } from "../../utils/progressType";
 import { PROGRESS_STATUS } from "../../constants/status";
+import SimpleAlertModal from "./SimpleAlertModal";
 
 const EDIT_MODAL_STATUS = ["진행 완료", "진행 중", "진행 예정"];
 
@@ -22,6 +23,8 @@ const EditProjectModal = ({
   title,
 }: EditProjectModalProps) => {
   const navigate = useNavigate();
+  const [startDateAlertMadalOpen, setStartDateAlertMadalOpen] = useState(false);
+  const [endDateAlertModalOpen, setEndDateAlertModalOpen] = useState(false);
 
   // 프로젝트 생성 페이지 상태
   const [pages, setPages] = useState<number>(0);
@@ -69,7 +72,11 @@ const EditProjectModal = ({
       setNewProjectNameValue(selectedProject.name);
 
       setEditStatus(selectedProject.status);
-      setSelectedMember(selectedProject.members);
+      setSelectedMember(
+        selectedProject.members.filter(
+          (member) => member.memberId !== selectedProject.creatorId
+        )
+      );
     }
 
     const startDate = selectedProject
@@ -361,8 +368,16 @@ const EditProjectModal = ({
                   css="text-main-green01 w-full text-[14px] bg-white border-[1px] border-main-green01"
                   onClick={() => {
                     setPages(1);
-                    console.log(newProjectInfo);
-                    newProjectPost(newProjectInfo);
+                    if (
+                      newProjectInfo.startDate <
+                      dayjs().format("YYYY-MM-DDTHH:mm:ss")
+                    ) {
+                      return setStartDateAlertMadalOpen(true);
+                    }
+                    if (newProjectInfo.startDate > newProjectInfo.endDate) {
+                      return setEndDateAlertModalOpen(true);
+                    }
+                    // newProjectPost(newProjectInfo);
                   }}
                 />
               )}
@@ -375,6 +390,7 @@ const EditProjectModal = ({
           />
         </div>
       </div>
+
       {/* 워드 클라우드 */}
       {/* {pages === 0 && selectedCategory.subCategories1 && (
         <div
@@ -415,6 +431,22 @@ const EditProjectModal = ({
           </div>
         </div>
       )} */}
+      {endDateAlertModalOpen && (
+        <div className="absolute top-[50px] z-20 bg-black/50 h-[calc(100vh-50px)] w-full flex items-center justify-center">
+          <SimpleAlertModal
+            text="종료 날짜는 시작 날짜보다 뒤로 설정해야합니다"
+            setIsModal={setEndDateAlertModalOpen}
+          />
+        </div>
+      )}
+      {startDateAlertMadalOpen && (
+        <div className="absolute top-[50px] z-20 bg-black/50 h-[calc(100vh-50px)] w-full flex items-center justify-center">
+          <SimpleAlertModal
+            text="시작 날짜는 현재 또는 미래여야 합니다"
+            setIsModal={setStartDateAlertMadalOpen}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/types/project.d.ts
+++ b/src/types/project.d.ts
@@ -3,6 +3,7 @@ interface EditProjectModalProps {
   selectedProject?: ProjectListType;
   setIsEditProjectModal: React.Dispatch<React.SetStateAction<boolean>>;
   title: string;
+  setIsAlertModalOpen?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 interface selectedProjectData {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 프로젝트 생성 시 모달에서 날짜 선택 제한했습니다.
- 시작 날짜는 하루 전부터 가능하고 종료 날짜는 시작날짜보다 뒤로 설정하도록 경고창 설정했습니다.
- 

## 🔗 관련 이슈

#198 

## 📸 스크린샷 (선택)

<img width="747" alt="스크린샷 2025-03-06 오후 4 02 32" src="https://github.com/user-attachments/assets/67730c8b-305e-41cb-aa89-243acdd195de" />

<img width="781" alt="스크린샷 2025-03-06 오후 4 02 48" src="https://github.com/user-attachments/assets/fdc73d8e-8ea9-4bb1-b393-10f926a27f09" />
