### PR TITLE
Feat 관리자페이지 업무검색 #219

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -46,3 +46,19 @@ export const searchProjects = async (
     throw error;
   }
 };
+
+// 업무 검색 API
+export const searchTasks = async (
+  title: string
+): Promise<TaskSearchResult[]> => {
+  try {
+    const response = await api.get(`/api/search/tasks`, {
+      params: { title },
+    });
+    console.log("업무 검색 성공", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("업무 검색 실패", error);
+    throw error;
+  }
+};

--- a/src/components/Admin/Task/AdminTask.tsx
+++ b/src/components/Admin/Task/AdminTask.tsx
@@ -67,19 +67,18 @@ const AdminTask = () => {
     // staleTime: 0,
   });
 
+  // 활성비활성 상태
+  const [taskMenu, setTaskMenu] = useState("active");
   // 활성 업무리스트 상태
   const [tasks, setTasks] = useState(taskList);
   // 비활성 업무리스트 상태
   const [deleteTasks, setDeleteTasks] = useState(deleteTaskList);
-  // 활성비활성 상태
-  const [taskMenu, setTaskMenu] = useState("active");
   // 전체 체크박스 체크 상태
   const [isChecked, setIsChecked] = useState(false);
   // 체크된 비활성 업무 상태
   const [isCheckedTask, setIsCheckedTask] = useState<number[]>([]);
   // 모달 상태
   const [isConfirmModal, setIsConfirmModal] = useState<boolean>(false);
-  console.log("체크된 비활성 업무 :", isCheckedTask);
 
   // 업무 수정
   const { mutateAsync: updateTaskFn } = useMutation({
@@ -182,18 +181,6 @@ const AdminTask = () => {
     (tasks?.length ? tasks?.length : 0) / itemsPerPage
   );
 
-  // 활성 비활성 버튼 클릭에 따른 데이터 분기처리
-  const paginatedTasks =
-    taskMenu === "active"
-      ? tasks?.slice(
-          (currentPage - 1) * itemsPerPage,
-          currentPage * itemsPerPage
-        )
-      : deleteTasks?.slice(
-          (currentPage - 1) * itemsPerPage,
-          currentPage * itemsPerPage
-        );
-
   // 체크박스 상태 변경 함수
   const toggleCheckBox = () => {
     setIsChecked((prev) => !prev);
@@ -203,6 +190,40 @@ const AdminTask = () => {
   useEffect(() => {
     setCurrentPage(1);
   }, [taskMenu]);
+
+  // 업무 검색 입력 상태
+  const [searchTaskName, setSearchTaskName] = useState<string>("");
+
+  // 검색 함수
+  const handleSearchTask = () => {
+    taskMenu === "active"
+      ? setTasks(
+          tasks?.filter((task) => task.taskName.includes(searchTaskName))
+        )
+      : setDeleteTasks(
+          deleteTasks?.filter((task) => task.taskName.includes(searchTaskName))
+        );
+  };
+
+  // 검색어가 없을 경우 원래 데이터로 초기화
+  useEffect(() => {
+    if (searchTaskName.trim() === "") {
+      setTasks(taskList);
+      setDeleteTasks(deleteTaskList);
+    }
+  }, [searchTaskName]);
+
+  // 페이지 구분
+  const filterTasks =
+    taskMenu === "active"
+      ? tasks?.slice(
+          (currentPage - 1) * itemsPerPage,
+          currentPage * itemsPerPage
+        )
+      : deleteTasks?.slice(
+          (currentPage - 1) * itemsPerPage,
+          currentPage * itemsPerPage
+        );
 
   return (
     <div className="h-[calc(100vh-50px)] bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0">
@@ -230,10 +251,18 @@ const AdminTask = () => {
           </div>
 
           {/* 검색 창 */}
-          <div className="flex gap-[10px]">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSearchTask();
+            }}
+            className="flex gap-[10px]"
+          >
             <input
               className="w-[250px] h-[27px] border border-header-green rounded-[5px] focus:outline-none flex px-[10px] items-center text-[14px]"
               placeholder="업무명 또는 프로젝트명 검색"
+              value={searchTaskName}
+              onChange={(e) => setSearchTaskName(e.target.value)}
             />
             <Button
               text="검색"
@@ -241,7 +270,7 @@ const AdminTask = () => {
               size="sm"
               css="h-[27px] text-[14px] text-main-beige01 bg-header-green"
             />
-          </div>
+          </form>
 
           {/* 삭제 버튼 */}
           <div className="flex gap-[5px] w-[80px] justify-end">
@@ -298,7 +327,7 @@ const AdminTask = () => {
           </div>
 
           {/* 업무목록 */}
-          {paginatedTasks?.map((task, index) => (
+          {filterTasks?.map((task, index) => (
             <AdminTaskList
               key={task.taskId}
               task={task}

--- a/src/hooks/useGoogleLogin.ts
+++ b/src/hooks/useGoogleLogin.ts
@@ -12,7 +12,10 @@ const useGoogleLogin = () => {
   const login = useAuthStore((state) => state.login);
 
   const CLIENT_ID = import.meta.env.VITE_GOOGLE_ID;
-  const REDIRECT_URI = "http://localhost:5173/signin";
+  const REDIRECT_URI =
+    window.location.hostname === "localhost"
+      ? "http://localhost:5173/signin"
+      : "https://errom.netlify.app/signin";
   const SCOPE = import.meta.env.VITE_GOOGLE_SCOPE;
 
   const handleGoogleLogin = () => {

--- a/src/types/task.d.ts
+++ b/src/types/task.d.ts
@@ -96,3 +96,14 @@ interface GetAssignedTask {
   participantProfiles: string[];
   projectId: number;
 }
+
+interface TaskSearchResult {
+  taskId: number;
+  taskName: string;
+  projectName: string;
+  assignedMemberName: string;
+  assignedMemberEmail: string;
+  taskStatus: "IN_PROGRESS" | "COMPLETED" | "BEFORE_START" | "HOLD";
+  startDate: string;
+  endDate: string;
+}


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자 페이지 - 업무 검색기능 구현했습니다
  -> 업무 데이터에는 활성 비활성을 구분하는 키 값이 없기 때문에 필터로 검색 기능 구현했습니다
- 구글 로그인 리다이렉트_URI 추가했습니다

## 🔗 관련 이슈

- 관련된 이슈 번호를 적어주세요. (예: `#3`)

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
