### PR TITLE
Fix 1차 배포 qa 업무생성편집모달 #240

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -38,7 +38,8 @@ api.interceptors.response.use(
 
     console.log("originalRequest._retry 값:", originalRequest._retry);
 
-    const { refreshToken, login, logout } = useAuthStore.getState();
+    const { idToken, member, refreshToken, login, logout } =
+      useAuthStore.getState();
 
     // 401 (Unauthorized) 또는 403 (Forbidden) 에러가 발생한 경우 처리
     if (
@@ -47,23 +48,19 @@ api.interceptors.response.use(
     ) {
       console.log("401 또는 403 에러 감지, 리프레시 토큰 실행");
       originalRequest._retry = true; // 이제 안전하게 true로 변경 가능
+      console.log(refreshToken);
 
       if (refreshToken) {
         try {
           console.log("리프레시 요청 보냄", refreshToken);
 
           // 기존 accessToken을 제거한 후 새로 요청
-          useAuthStore.getState().login(null, null, refreshToken, null);
+          useAuthStore.getState().login(idToken, null, refreshToken, member);
 
           const res = await api.post("/api/auth/refresh", { refreshToken });
 
           // 새 accessToken 저장
-          login(
-            res.data.idToken,
-            res.data.accessToken,
-            res.data.refreshToken,
-            res.data.member
-          );
+          login(idToken, res.data.accessToken, res.data.refreshToken, member);
 
           // 요청 헤더 업데이트 후 재시도
           originalRequest.headers.Authorization = `Bearer ${res.data.accessToken}`;

--- a/src/api/project.ts
+++ b/src/api/project.ts
@@ -27,7 +27,7 @@ export const postProject = async (projectData: postProjectType) => {
 //프로젝트 수정 전 기존 프로젝트 정보 불러오기
 export const getProjectById = async (
   projectId: string
-): Promise<ProjectDetailType> => {
+): Promise<GetProjectById> => {
   try {
     const response = await api.get(`/api/projects/${projectId}/edit`, {
       params: { projectId },

--- a/src/components/EditProjectModal/SelectMember.tsx
+++ b/src/components/EditProjectModal/SelectMember.tsx
@@ -107,6 +107,7 @@ const SelectMember = <T extends "업무" | "프로젝트">({
       }
     }
   };
+  console.log(memberData);
 
   /* 취소 버튼 클릭 시 선택된 팀원에서 제거 */
   const handleCancelClick = (id: number) => {

--- a/src/components/MainPage/TodaySchedule.tsx
+++ b/src/components/MainPage/TodaySchedule.tsx
@@ -74,7 +74,7 @@ const TodaySchedule = ({ taskData, isLoading }: TodayScheduleProps) => {
           {year}년 {month}월 {nowDate}일 ({day})
         </p>
         <p className="font-bold text-[26px]" ref={timeRef}>
-          00:00:00
+          현재 시간
         </p>
       </div>
 

--- a/src/components/Task/TaskBox.tsx
+++ b/src/components/Task/TaskBox.tsx
@@ -17,11 +17,6 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
     },
   });
 
-  // console.log(updatedData);
-  // console.log(task);
-  // console.log(updatedData);
-  // console.log(task);
-
   /* 시작버튼 클릭 -> 진행 중 상태 변경 함수 */
   const handleStateStart = () => {
     if (!updatedData) return; // undefined 체크
@@ -49,7 +44,7 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
   };
 
   // 전체 업무 박스
-  if (isAll && updatedData) {
+  if (isAll && task) {
     return (
       <div
         className={`w-[320px] h-[120px] bg-white border border-main-green02
@@ -63,17 +58,15 @@ const TaskBox = ({ isAll = true, onClick, task, onUpdate }: TaskBoxProps) => {
         <div className="flex justify-between items-center">
           <p className="font-bold">{task?.title}</p>
           <p className="text-[12px] font-medium">
-            {PROGRESS_STATUS[updatedData.status]}
+            {PROGRESS_STATUS[task.status]}
           </p>
         </div>
 
         {/* 기간, 업무완료,시잔 버튼 */}
         <div className="flex justify-between items-center">
           <p className="text-[12px]">
-            {updatedData &&
-              `${updatedData.startDate.split("T")[0]} ~ ${
-                updatedData.endDate.split("T")[0]
-              }`}
+            {task &&
+              `${task.startDate.split("T")[0]} ~ ${task.endDate.split("T")[0]}`}
           </p>
           {task.assignedMemberName === member?.username &&
             (task.status !== "IN_PROGRESS" ? (

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -8,7 +8,7 @@ import { useAuthStore } from "../../store/authStore";
 const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const { member } = useAuthStore();
-  // console.log(member);
+  console.log(member);
 
   const openModal = (task: Task) => {
     setSelectedTask(task); // 임의로 첫 번째 더미 데이터를 선택
@@ -29,6 +29,10 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
       taskId: number;
       updateData: UpdateTask;
     }) => updateTask(taskId, updateData),
+    onSuccess: () => {
+      refetch();
+      console.log("성공");
+    },
   });
 
   const handleUpdateTask = async (taskId: number, updateData: UpdateTask) => {
@@ -50,8 +54,10 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
   const deleteMutation = useMutation({
     mutationFn: async (taskId: number) => {
       await deleteTask(taskId);
-
-      refetch(); // 삭제 후 refetch 호출
+    },
+    onSuccess: () => {
+      refetch();
+      console.log("성공");
     },
   });
 

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import TaskBox from "./TaskBox";
 import UpdateTaskModal from "../modals/UpdateTaskModal";
 import { useMutation } from "@tanstack/react-query";

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -5,10 +5,16 @@ import { useMutation } from "@tanstack/react-query";
 import { deleteTask, updateTask } from "../../api/task";
 import { useAuthStore } from "../../store/authStore";
 
-const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
+const TaskList = ({
+  name,
+  isAll = true,
+  taskInfo,
+  refetch,
+  projectData,
+}: TaskListProps) => {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const { member } = useAuthStore();
-  console.log(member);
+  // console.log(projectData?.members);
 
   const openModal = (task: Task) => {
     setSelectedTask(task); // 임의로 첫 번째 더미 데이터를 선택
@@ -110,6 +116,7 @@ const TaskList = ({ name, isAll = true, taskInfo, refetch }: TaskListProps) => {
             onDelete={handleDeleteTask}
             onUpdate={handleUpdateTask}
             refetch={refetch}
+            projectData={projectData}
           />
         </div>
       )}

--- a/src/components/Task/TaskList.tsx
+++ b/src/components/Task/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import TaskBox from "./TaskBox";
 import UpdateTaskModal from "../modals/UpdateTaskModal";
 import { useMutation } from "@tanstack/react-query";
@@ -23,8 +23,6 @@ const TaskList = ({
   const closeModal = () => {
     setSelectedTask(null);
   };
-
-  // console.log(taskInfo);
 
   /* 업무 수정 */
   const updateMutation = useMutation({

--- a/src/components/modals/UpdateTaskModal.tsx
+++ b/src/components/modals/UpdateTaskModal.tsx
@@ -16,6 +16,7 @@ const UpdateTaskModal = ({
   onDelete,
   onUpdate,
   refetch,
+  projectData,
 }: UpdateTaskModalProps) => {
   const [isConfirmModal, setIsConfirmModal] = useState<boolean>(false);
   const loginUser = useAuthStore((state) => state.member);
@@ -94,6 +95,7 @@ const UpdateTaskModal = ({
       memberId: updatedData?.participantIds?.[0] ?? 0,
     },
   ]);
+  console.log(memberData);
 
   const [taskName, setTaskName] = useState<string>(task.title);
 
@@ -148,6 +150,7 @@ const UpdateTaskModal = ({
         selectedData={updatedData}
         selectedMembers={memberData}
         setSelectedMembers={setMemberData}
+        memberData={projectData?.members}
         value="업무"
       />
       <div>
@@ -224,8 +227,8 @@ const UpdateTaskModal = ({
           onClick={() => {
             if (onUpdate) {
               onUpdate(task.taskId, taskInfo);
-              refetch();
             }
+            refetch();
           }}
           css="border border-main-green01 text-main-green01 font-bold text-[14px]  w-[89px] h-[27px]"
         />

--- a/src/pages/ProjectRoom/ProjectRoomDetail.tsx
+++ b/src/pages/ProjectRoom/ProjectRoomDetail.tsx
@@ -7,7 +7,7 @@ import CreateTaskModal from "../../components/modals/CreateTaskModal";
 import { useQuery } from "@tanstack/react-query";
 import { OutletContextType } from "../../components/layout/Layout";
 import { useSideManagerStore } from "../../store/sideMemberStore";
-import { getProjectDetail } from "../../api/project";
+import { getProjectById, getProjectDetail } from "../../api/project";
 
 interface ProjectDetailType {
   projectId: number;
@@ -60,14 +60,22 @@ const ProjectRoomDetail = () => {
   const {
     data: projectDetailList,
     isLoading,
-    refetch,
+    refetch: getProjectDetailRefetch,
   } = useQuery<ProjectDetailType>({
     queryKey: ["ProjectDetail", projectId],
     queryFn: async () => {
       return await getProjectDetail(Number(projectId!));
     },
   });
-  console.log(projectDetailList?.members);
+
+  console.log(projectDetailList);
+
+  const { data: projectEditInfo } = useQuery<GetProjectById>({
+    queryKey: ["ProjectEditInfo", projectId],
+    queryFn: async () => {
+      return await getProjectById(projectId as string);
+    },
+  });
 
   // 전체 업무 상태
   const [allTasks, setAllTasks] = useState<AllTasksType>({
@@ -89,8 +97,6 @@ const ProjectRoomDetail = () => {
       setMember(projectDetailList.members);
     }
   }, [projectDetailList]);
-
-  console.log(member);
 
   useEffect(() => {
     console.log(projectDetailList, isLoading);
@@ -114,7 +120,6 @@ const ProjectRoomDetail = () => {
           HOLD: [],
         }
       );
-
       setAllTasks(tasksGroup);
 
       // 담당자별 업무
@@ -227,22 +232,26 @@ const ProjectRoomDetail = () => {
               <TaskList
                 name="진행 중"
                 taskInfo={allTasks.IN_PROGRESS}
-                refetch={refetch}
+                refetch={getProjectDetailRefetch}
+                projectData={projectDetailList}
               />
               <TaskList
                 name="진행 예정"
                 taskInfo={allTasks.BEFORE_START}
-                refetch={refetch}
+                refetch={getProjectDetailRefetch}
+                projectData={projectDetailList}
               />
               <TaskList
                 name="진행 완료"
                 taskInfo={allTasks.COMPLETED}
-                refetch={refetch}
+                refetch={getProjectDetailRefetch}
+                projectData={projectDetailList}
               />
               <TaskList
                 name="보류"
                 taskInfo={allTasks.HOLD}
-                refetch={refetch}
+                refetch={getProjectDetailRefetch}
+                projectData={projectDetailList}
               />
             </div>
           )}
@@ -259,7 +268,7 @@ const ProjectRoomDetail = () => {
                       isAll={false}
                       taskInfo={task.tasks}
                       name={task.name}
-                      refetch={refetch}
+                      refetch={getProjectDetailRefetch}
                     />
                   </div>
                 );
@@ -279,9 +288,10 @@ const ProjectRoomDetail = () => {
               <CreateTaskModal
                 onClose={setIsEditTaskModal}
                 projectId={Number(projectId)}
-                refetch={refetch}
+                refetch={getProjectDetailRefetch}
                 setIsModal={setIsEditTaskModal}
                 memberData={member}
+                projectData={projectEditInfo}
               />
             </div>
           )}

--- a/src/pages/ProjectRoom/ProjectRoomDetail.tsx
+++ b/src/pages/ProjectRoom/ProjectRoomDetail.tsx
@@ -141,6 +141,7 @@ const ProjectRoomDetail = () => {
       setManageTasks(manageGroupTasks);
     }
   }, [projectDetailList]);
+  console.log(allTasks);
 
   // 사이드바에서 체크된 담당자
   const checkedManagers = useSideManagerStore((state) => state.checkedManagers);

--- a/src/types/project.d.ts
+++ b/src/types/project.d.ts
@@ -87,17 +87,13 @@ interface postProjectType {
 
 // getProjectById API 타입 지정
 interface ProjectDetailType {
-  id: number;
-  name: string;
-  category: string;
-  subCategories1: string[];
-  subCategories2: string[];
-  startDate: string;
-  endDate: string;
-  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED" | "HOLD";
-  memberIds: number[];
-  memberNames: string[];
-  memberProfiles: (string | null)[];
+  projectId: number;
+  projectName: string;
+  categoryName: string;
+  subCategories: subCategories[];
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
+  tasks: Task[];
+  members: members[];
 }
 
 //patchProjectById  입력값 타입 지정
@@ -139,4 +135,19 @@ interface ProjectSearchResult {
   createdAt: string;
   projectStatus: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED" | "HOLD";
   deleteStatus: "ACTIVE" | "DELETED";
+}
+
+interface GetProjectById {
+  id: number;
+  name: string;
+  categoryName: string;
+  subCategories: {
+    id: number;
+    name: string;
+    tags: { id: number; name: string }[];
+  }[];
+  startDate: string;
+  endDate: string;
+  status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED";
+  members: { memberId: number; username: string; profile: string }[];
 }

--- a/src/types/projectDetailList.d.ts
+++ b/src/types/projectDetailList.d.ts
@@ -4,7 +4,7 @@ interface ProjectDetailType {
   categoryName: string;
   subCategories: subCategories[];
   status: "BEFORE_START" | "IN_PROGRESS" | "COMPLETED"; // 프로젝트 상태 Enum
-  tasks: tasks[];
+  tasks: Task[];
   members: members[];
 }
 

--- a/src/types/task.d.ts
+++ b/src/types/task.d.ts
@@ -6,6 +6,7 @@ interface UpdateTaskModalProps {
   onDelete?: (taskId: number) => void;
   onUpdate?: (taskId: number, updateData: UpdateTask) => void;
   refetch: () => void;
+  projectData?: ProjectDetailType;
 }
 
 interface selectedDateType {
@@ -22,6 +23,7 @@ interface TaskListProps {
   isAll?: boolean;
   taskInfo: Task[];
   refetch: () => void;
+  projectData?: ProjectDetailType;
 }
 
 interface TaskBoxProps {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 리프레쉬 토큰으로 로그인 시 유저 정보를 불러오지 못하는 버그를 수정했습니다.
- 업무편집생성모달 - 시작/종료일을 프로젝트 시작/종료일로 설정했습니다.
- 프로젝트 기간을 벗어나면 모달이 열리면서 기간 설정에 제한을 주었습니다.
- 프로젝트 참여 인원임에도 참여인원이 아니라는 모달이 뜨는 버그를 해결했습니다.
- 업무 편집 시 업무박스에 바로 렌더링 되지 않는 부분을 수정했습니다.

## 🔗 관련 이슈

- 관련된 이슈 번호를 적어주세요. (예: `#3`)

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
