### PR TITLE
Feat 관리자 복구기능 구현 #241

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -64,6 +64,19 @@ export const deleteAdminAccount = async (member_id: number) => {
   }
 };
 
+// 관리자 계정 활성 전환(복구)
+export const adminRestoreAccount = async (memberId: number) => {
+  try {
+    const response = await api.patch(
+      `/admin/manage/member/${memberId}/activate`
+    );
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 // 관리자 활성 프로젝트 리스트
 export const getAdminProjectList = async () => {
   try {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -192,3 +192,14 @@ export const deleteTask = async (taskId: number) => {
     console.error("업무 삭제 실패", error);
   }
 };
+
+// 관리자 업무 활성 전환 (복구)
+export const adminRestoreTask = async (taskId: number) => {
+  try {
+    const response = await api.patch(`/admin/manage/task/${taskId}/activate`);
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -131,6 +131,19 @@ export const adminDeleteProject = async (projectId: number) => {
   }
 };
 
+// 관리자 프로젝트 활성 전환 (복구)
+export const adminRestoreProject = async (projectId: number) => {
+  try {
+    const response = await api.patch(
+      `/admin/manage/project/${projectId}/activate`
+    );
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 // 관리자 활성 업무 리스트
 export const getAdminTaskList = async () => {
   try {

--- a/src/components/Admin/Account/AdminAccount.tsx
+++ b/src/components/Admin/Account/AdminAccount.tsx
@@ -132,6 +132,7 @@ const AdminAccount = () => {
 
   useEffect(() => {
     setCurrentPage(1);
+    setCheckedAccountIds([]);
   }, [userMenu]);
 
   // 모달 적용
@@ -301,7 +302,6 @@ const AdminAccount = () => {
               key={user.memberId}
               user={user}
               index={(currentPage - 1) * itemsPerPage + index}
-              checkedAccountIds={checkedAccountIds}
               setCheckedAccountIds={setCheckedAccountIds}
             />
           ))}

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -12,13 +12,13 @@ import AdminEditCancelBtn from "../Button/AdminEditCancelBtn";
 const AdminAccountList = ({
   user,
   index,
-  deleteAccountIds,
-  setDeleteAccountIds,
+  checkedAccountIds,
+  setCheckedAccountIds,
 }: {
   user: AccountListProps;
   index: number;
-  deleteAccountIds: number[];
-  setDeleteAccountIds: React.Dispatch<React.SetStateAction<number[]>>;
+  checkedAccountIds: number[];
+  setCheckedAccountIds: React.Dispatch<React.SetStateAction<number[]>>;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState({ ...user });
@@ -38,15 +38,15 @@ const AdminAccountList = ({
 
   useEffect(() => {
     if (isChecked) {
-      setDeleteAccountIds((prev) => [...prev, user.memberId]);
+      setCheckedAccountIds((prev) => [...prev, user.memberId]);
     } else {
-      setDeleteAccountIds((prev) => prev.filter((id) => id !== user.memberId));
+      setCheckedAccountIds((prev) => prev.filter((id) => id !== user.memberId));
     }
   }, [isChecked]);
 
   useEffect(() => {
-    console.log(deleteAccountIds);
-  }, [deleteAccountIds]);
+    console.log(checkedAccountIds);
+  }, [checkedAccountIds]);
 
   // 계정 관리 수정요청 데이터
   const editAccountData: EditAccountType = {

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -12,12 +12,10 @@ import AdminEditCancelBtn from "../Button/AdminEditCancelBtn";
 const AdminAccountList = ({
   user,
   index,
-  checkedAccountIds,
   setCheckedAccountIds,
 }: {
   user: AccountListProps;
   index: number;
-  checkedAccountIds: number[];
   setCheckedAccountIds: React.Dispatch<React.SetStateAction<number[]>>;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -43,10 +41,6 @@ const AdminAccountList = ({
       setCheckedAccountIds((prev) => prev.filter((id) => id !== user.memberId));
     }
   }, [isChecked]);
-
-  useEffect(() => {
-    console.log(checkedAccountIds);
-  }, [checkedAccountIds]);
 
   // 계정 관리 수정요청 데이터
   const editAccountData: EditAccountType = {

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -13,9 +13,11 @@ const AdminAccountList = ({
   user,
   index,
   setCheckedAccountIds,
+  checkedAccountIds,
 }: {
   user: AccountListProps;
   index: number;
+  checkedAccountIds: number[];
   setCheckedAccountIds: React.Dispatch<React.SetStateAction<number[]>>;
 }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -30,17 +32,31 @@ const AdminAccountList = ({
 
   const [isChecked, setIsChecked] = useState(false);
 
+  useEffect(() => {
+    if (checkedAccountIds.includes(user.memberId)) {
+      setIsChecked(true);
+    } else {
+      setIsChecked(false);
+    }
+  }, [checkedAccountIds]);
+
   const toggleCheckBox = () => {
-    setIsChecked((prev) => !prev);
+    if (checkedAccountIds.includes(user.memberId)) {
+      setCheckedAccountIds((prev) => prev.filter((id) => id !== user.memberId));
+      setIsChecked(false);
+    } else {
+      setCheckedAccountIds((prev) => [...prev, user.memberId]);
+      setIsChecked(true);
+    }
   };
 
-  useEffect(() => {
-    if (isChecked) {
-      setCheckedAccountIds((prev) => [...prev, user.memberId]);
-    } else {
-      setCheckedAccountIds((prev) => prev.filter((id) => id !== user.memberId));
-    }
-  }, [isChecked]);
+  // useEffect(() => {
+  //   if (isChecked) {
+  //     setCheckedAccountIds((prev) => [...prev, user.memberId]);
+  //   } else {
+  //     setCheckedAccountIds((prev) => prev.filter((id) => id !== user.memberId));
+  //   }
+  // }, [isChecked]);
 
   // 계정 관리 수정요청 데이터
   const editAccountData: EditAccountType = {

--- a/src/components/Admin/Project/AdminProject.tsx
+++ b/src/components/Admin/Project/AdminProject.tsx
@@ -11,6 +11,7 @@ import AdminProjectList from "./AdminProjectList";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   adminDeleteProject,
+  adminRestoreProject,
   getAdminInActiveProjectList,
   getAdminProjectList,
 } from "../../../api/admin";
@@ -174,6 +175,34 @@ const AdminProject = () => {
     },
   });
 
+  // 프로젝트 활성 전환(복구)
+  const { mutateAsync: restoreProject } = useMutation({
+    mutationFn: (projectId: number) => adminRestoreProject(projectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["AdminAcitveProject"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["AdminInAcitveProject"] });
+      setCheckedIds([]);
+    },
+  });
+
+  const handleRestoreProject = () => {
+    if (checkedIds.length === 0) {
+      return openModal("프로젝트를 선택해주세요");
+    }
+
+    // 삭제 확인 모달 띄우기
+    openModal(`${checkedIds.length}개의 프로젝트를 복구하시겠습니까?`, () => {
+      checkedIds.forEach(async (id) => {
+        const response = await restoreProject(id);
+        console.log(response, "del");
+      });
+      closeModal();
+      alert("프로젝트를 복구했습니다.");
+    });
+  };
+
   return (
     <div className="h-[calc(100vh-50px)] bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0">
       <div className="min-h-[calc(100vh-80px)] mx-[30px] mb-[30px] px-[30px] pt-[30px] flex flex-col bg-white/60">
@@ -219,8 +248,11 @@ const AdminProject = () => {
           <div className="flex gap-[5px] w-[80px] justify-end">
             {projectMenu === "inactive" && (
               <>
-                <button>
-                  <img src={ResotreIcon} alt="계정 복구 버튼" />
+                <button
+                  onClick={handleRestoreProject}
+                  className="cursor-pointer"
+                >
+                  <img src={ResotreIcon} alt="복구 버튼" />
                 </button>
                 <AdminDeleteBtn onClick={deleteProjects} />
               </>

--- a/src/components/Admin/Project/AdminProjectList.tsx
+++ b/src/components/Admin/Project/AdminProjectList.tsx
@@ -15,6 +15,7 @@ import { queryClient } from "../../../main";
 interface AdminProjectListProps {
   project: AdminProjectsListType;
   index: number;
+  checkedIds: number[];
   setCheckedIds: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
@@ -22,6 +23,7 @@ const AdminProjectList = ({
   project,
   index,
   setCheckedIds,
+  checkedIds,
 }: AdminProjectListProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -41,17 +43,23 @@ const AdminProjectList = ({
 
   const [isChecked, setIsChecked] = useState(false);
 
-  const toggleCheckBox = () => {
-    setIsChecked((prev) => !prev);
-  };
-
   useEffect(() => {
-    if (isChecked) {
-      setCheckedIds((prev) => [...prev, project.projectId]);
+    if (checkedIds.includes(project.projectId)) {
+      setIsChecked(true);
     } else {
-      setCheckedIds((prev) => prev.filter((id) => id !== project.projectId));
+      setIsChecked(false);
     }
-  }, [isChecked]);
+  }, [checkedIds]);
+
+  const handleCheckBoxClick = () => {
+    if (checkedIds.includes(project.projectId)) {
+      setCheckedIds((prev) => prev.filter((id) => id !== project.projectId));
+      setIsChecked(false);
+    } else {
+      setCheckedIds((prev) => [...prev, project.projectId]);
+      setIsChecked(true);
+    }
+  };
 
   // 진행상태 체크
   const [status, setStatus] = useState<string>(
@@ -116,7 +124,7 @@ const AdminProjectList = ({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              toggleCheckBox();
+              handleCheckBoxClick();
             }}
             className="cursor-pointer"
           >


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자페이지 계정/프로젝트/업무 부분 복구기능 구현했습니다.
- 관리자 계정/프로젝트 부분 전체선택  기능 추가했습니다.
- 계정, 프로젝트 삭제 로직 수정했습니다.

## 🔗 관련 이슈

#241 

## 📸 스크린샷 (선택)
<img width="1480" alt="스크린샷 2025-03-08 오전 2 31 24" src="https://github.com/user-attachments/assets/39aef1a5-6fe4-4a8c-8860-7704dc47ee00" />

<img width="1544" alt="스크린샷 2025-03-08 오전 2 32 35" src="https://github.com/user-attachments/assets/03568aec-02b0-4ffa-a52a-3827a5c8d9f0" />


