### PR TITLE
<Merge/fix_1차배포qa-미팅룸회의록알람-수정_#239>fix: 1차배포qa수정 #239

### DIFF
--- a/src/components/AlamModal/AlarmBox.tsx
+++ b/src/components/AlamModal/AlarmBox.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router";
 import { twMerge } from "tailwind-merge";
+import { getProjectList } from "../../api/project";
+import { useQuery } from "@tanstack/react-query";
 
 const AlarmBox = ({
   id,
@@ -48,14 +50,28 @@ const AlarmBox = ({
     PROJECT_EXIT: projectId,
   }[theme];
 
-  const THEME_NAVIGATE = {
-    MESSAGE_SEND: `/project-room/${THEME_ID}?category=meeting`,
-    TASK_ASSIGN: `/project-room/${THEME_ID}`,
-    PROJECT_INVITE: `/project-room/${THEME_ID}`,
-    PROJECT_EXIT: `/project-room/${THEME_ID}`,
-  }[theme];
+  // 프로젝트리스트 데이터
+  const { data: projectRoomList = [] } = useQuery<ProjectListType[]>({
+    queryKey: ["ProjectRoomList"],
+    queryFn: async () => {
+      return await getProjectList();
+    },
+  });
 
   const handleClick = () => {
+    const validProjectIds = projectRoomList.map((project) =>
+      String(project.id)
+    );
+
+    const THEME_NAVIGATE = validProjectIds.includes(THEME_ID)
+      ? {
+          MESSAGE_SEND: `/project-room/${THEME_ID}?category=meeting`,
+          TASK_ASSIGN: `/project-room/${THEME_ID}`,
+          PROJECT_INVITE: `/project-room/${THEME_ID}`,
+          PROJECT_EXIT: `/project-room/${THEME_ID}`,
+        }[theme]
+      : "/not-found";
+
     console.log("알람 클릭됨, ID:", id, "NAVIGATE:", THEME_NAVIGATE);
     navigate(THEME_NAVIGATE);
   };
@@ -69,8 +85,8 @@ const AlarmBox = ({
       }}
     >
       <div className="flex flex-col gap-[5px]">
-        <span className="text-[12px] font-bold">{THEME_TEXT}</span>
-        <span className="text-[10px] ">{THEME_FROM}</span>
+        <span className="text-[13px] font-bold">{THEME_TEXT}</span>
+        <span className="text-[11px] ">{THEME_FROM}</span>
       </div>
     </div>
   );

--- a/src/components/modals/CreateNotePeriodModal.tsx
+++ b/src/components/modals/CreateNotePeriodModal.tsx
@@ -4,6 +4,7 @@ import DateTimeSelect from "../EditProjectModal/DateTimeSelect";
 import CreateAINoteModal from "./CreateAINoteModal";
 import { useMutation } from "@tanstack/react-query";
 import { getAINote } from "../../api/meetingroom";
+import AlertModal from "../common/AlertModal";
 
 const CreateNotePeriodModal = ({
   onClose,
@@ -37,6 +38,7 @@ const CreateNotePeriodModal = ({
 
   const [isRunAI, setIsRunAI] = useState(false);
   const [title, setTitle] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
@@ -69,19 +71,36 @@ const CreateNotePeriodModal = ({
       await getAINote(chatRoomId, title, startTime, endTime),
   });
 
+  const [errorMessage, setErrorMessage] = useState("");
+
   const handleRunAI = () => {
-    fetchAINote({
-      chatRoomId,
-      title,
-      startTime,
-      endTime,
-    });
-    setIsRunAI(true);
+    if (title.trim() === "") {
+      setErrorMessage("제목을 입력해주세요");
+      setIsModalOpen(true);
+      return;
+    }
+    fetchAINote(
+      {
+        chatRoomId,
+        title,
+        startTime,
+        endTime,
+      },
+      {
+        onSuccess: () => {
+          setIsRunAI(true);
+        },
+        onError: () => {
+          setErrorMessage("해당 시간에 기록된 채팅이 없습니다.");
+          setIsModalOpen(true);
+        },
+      }
+    );
   };
 
-  useEffect(() => {
-    console.log(" AI 회의록 데이터:", AINote);
-  }, [AINote]);
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
   return (
     <>
@@ -136,6 +155,11 @@ const CreateNotePeriodModal = ({
               onClick={onClose}
             />
           </div>
+          {isModalOpen && (
+            <div className="fixed inset-0 flex items-center justify-center bg-black/30 z-50">
+              <AlertModal text={errorMessage} onClose={closeModal} />
+            </div>
+          )}
         </div>
       ) : (
         <div className="fixed inset-0 flex items-center justify-center  z-50">

--- a/src/pages/ProjectRoom/ProjectRoom.tsx
+++ b/src/pages/ProjectRoom/ProjectRoom.tsx
@@ -7,12 +7,6 @@ import EditProjectModal from "../../components/modals/EditProjectModal";
 import { useQuery } from "@tanstack/react-query";
 import { getProjectList } from "../../api/project";
 
-interface ProjectRoomData {
-  completed: ProjectListType[];
-  inProgress: ProjectListType[];
-  beforeStart: ProjectListType[];
-}
-
 const PROJECT_TAB: (
   | "진행 완료 프로젝트"
   | "진행 중인 프로젝트"

--- a/src/pages/ProjectRoom/ProjectRoomDetail.tsx
+++ b/src/pages/ProjectRoom/ProjectRoomDetail.tsx
@@ -175,7 +175,7 @@ const ProjectRoomDetail = () => {
     <>
       {/* 미팅룸 */}
       {category === "meeting" ? (
-        <div className="flex flex-col gap-10 w-full min-h-[calc(100vh-60px)] bg-white/60 ">
+        <div className="flex flex-col gap-10 w-full min-h-[calc(100vh-60px)] bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0 ">
           <MeetingRoomChatBox css="pb-[30px]" projectId={Number(projectId)} />
         </div>
       ) : (

--- a/src/store/useWebSocketStore.ts
+++ b/src/store/useWebSocketStore.ts
@@ -111,7 +111,7 @@ const useWebSocketStore = create<WebSocketStore>((set, get) => {
           }
 
           console.log(
-            "🌐 현재 미팅룸 category:",
+            " 현재 미팅룸 category:",
             category,
             "projectId:",
             projectId

--- a/src/types/projectList.d.ts
+++ b/src/types/projectList.d.ts
@@ -14,6 +14,12 @@ interface ProjectListType {
   colors: Colors;
 }
 
+interface ProjectRoomData {
+  completed: ProjectListType[];
+  inProgress: ProjectListType[];
+  beforeStart: ProjectListType[];
+}
+
 // interface ProjectDetailType {
 //   id: number;
 //   name: string;


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

* 프로젝트룸에서 이동하는 미팅룸에 배경 추가했습니다.
* AI회의록 제목 작성 안하면 알람 모달 띄우고 다음 모달로 넘어가지 않도록 막았습니다.
* AI회의록에서 설정한 시간에 띄워줄 내용이 없으면 ‘ 해당 시간에 채팅 기록이 없습니다’ 기본으로 띄우기
=> 이렇게 띄우게 되면 회의록 생성이 안된 것이기 때문에 reportId가 없어서 회의록 등록이 안됩니다. (기록이 없다고 뜨더라도 사용자가 수정해 등록하고자 할 수 있음)
=> 따라서 회의록 생성이 안되면 시간 설정해달라는 모달 띄우고 다음 모달로 넘어가지 않도록 막았습니다. 
* 알람 모달에서 메시지랑 프로젝트, 업무명 각각 1px씩 키웠습니다.
* 프로젝트 참여인원 수정해 사용자가 프로젝트에서 빠질 시, 해당 프로젝트에 대해 남아있는 알람 클릭하면 해당 프로젝트 룸이 아닌 404페이지로 이동하도록 수정했습니다.  

## 🔗 관련 이슈

- #239

## 📸 스크린샷 (선택)

<img width="677" alt="스크린샷 2025-03-08 오후 4 01 48" src="https://github.com/user-attachments/assets/acbeb125-c25d-4082-a319-a741b012c1a8" />
<img width="677" alt="스크린샷 2025-03-08 오후 4 01 56" src="https://github.com/user-attachments/assets/c3b5f3d8-2fbe-4774-a465-cfcbb739999d" />

