### PR TITLE
Fix 마이페이지 기본이미지 변경오류 #247

### DIFF
--- a/src/api/myPage.ts
+++ b/src/api/myPage.ts
@@ -14,9 +14,12 @@ export const getMyPageInfo = async () => {
 // 내 정보 수정
 export const editMyPageInfo = async (formData: FormData) => {
   try {
-    const response = await api.putForm("api/mypage", formData);
-    console.log(response);
-    return response;
+    // const response = await api.putForm("api/mypage", formData);
+    formData.forEach((value, key) => {
+      console.log(key, value); // 각 키-값 쌍을 출력
+    });
+    // console.log(response);
+    // return response;
   } catch (error) {
     console.error(error);
   }

--- a/src/api/myPage.ts
+++ b/src/api/myPage.ts
@@ -14,12 +14,12 @@ export const getMyPageInfo = async () => {
 // 내 정보 수정
 export const editMyPageInfo = async (formData: FormData) => {
   try {
-    // const response = await api.putForm("api/mypage", formData);
+    const response = await api.putForm("api/mypage", formData);
     formData.forEach((value, key) => {
       console.log(key, value); // 각 키-값 쌍을 출력
     });
-    // console.log(response);
-    // return response;
+    console.log(response);
+    return response;
   } catch (error) {
     console.error(error);
   }

--- a/src/components/Admin/Account/AdminAccountList.tsx
+++ b/src/components/Admin/Account/AdminAccountList.tsx
@@ -60,7 +60,7 @@ const AdminAccountList = ({
 
   // 계정 관리 수정요청 데이터
   const editAccountData: EditAccountType = {
-    newName: editedUser.username,
+    name: editedUser.username,
   };
 
   // 계정관리 수정 함수

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -31,6 +31,7 @@ const MyPage = () => {
       setCompanyInfo(myPageInfo.organization);
       setProfileImgUrl(myPageInfo.profile);
     }
+    console.log("first");
   }, [myPageInfo]);
 
   const [isConfirmModal, setIsConfirmModal] = useState<boolean>(false);
@@ -72,17 +73,25 @@ const MyPage = () => {
     setIsFileDialogOpen(true);
   };
 
-  // 정보 수정 성공 시 모달 오픈
-  const [editSuccessModalOpen, setEditSuccessModalOpen] = useState(false);
-
   // 내 정보 수정 폼데이터
   const formData = new FormData();
   formData.append("username", name);
   formData.append("organization", companyInfo);
 
   if (profileImgFile) {
+    // 프로필 이미지를 변경한 경우
     formData.append("profileImage", profileImgFile);
   }
+
+  if (profileImgUrl === null) {
+    const emptyFile = new File([""], "empty.jpg", { type: "image/jpeg" });
+    formData.append("profileImage", emptyFile);
+  }
+
+  useEffect(() => {
+    console.log("profileImgUrl", profileImgUrl);
+    console.log("profileImgFile", profileImgFile);
+  }, [profileImgUrl, profileImgFile]);
 
   // 정보 수정 함수
   const { mutate: editMyInfo } = useMutation({
@@ -92,6 +101,9 @@ const MyPage = () => {
       setEditSuccessModalOpen(true);
     },
   });
+
+  // 정보 수정 성공 시 모달 오픈
+  const [editSuccessModalOpen, setEditSuccessModalOpen] = useState(false);
 
   if (isLoading) {
     return (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { editMyPageInfo, getMyPageInfo } from "../api/myPage";
 import { queryClient } from "../main";
 import SimpleAlertModal from "../components/modals/SimpleAlertModal";
+import AlertModal from "../components/common/AlertModal";
 
 interface MyPageInfoType {
   email: string;
@@ -21,6 +22,19 @@ const MyPage = () => {
     queryFn: getMyPageInfo,
   });
 
+  const [modalText, setModalText] = useState<string>("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = (text: string) => {
+    setModalText(text);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalText("");
+    setIsModalOpen(false);
+  };
+
   const [companyInfo, setCompanyInfo] = useState<string>("");
   const [name, setName] = useState<string>("");
   const [profileImgFile, setProfileImgFile] = useState<File>();
@@ -31,7 +45,6 @@ const MyPage = () => {
       setCompanyInfo(myPageInfo.organization);
       setProfileImgUrl(myPageInfo.profile);
     }
-    console.log("first");
   }, [myPageInfo]);
 
   const [isConfirmModal, setIsConfirmModal] = useState<boolean>(false);
@@ -218,7 +231,7 @@ const MyPage = () => {
             <div className="flex flex-col gap-[10px]">
               {/* 이름 */}
               <div className="flex flex-col gap-[5px]">
-                <span className="font-bold">이름</span>
+                <span className="font-bold text-[14px]">이름</span>
                 <input
                   type="text"
                   value={name}
@@ -230,7 +243,7 @@ const MyPage = () => {
 
               {/* 이메일 */}
               <div className="flex flex-col gap-[5px]">
-                <span className="font-bold">이메일</span>
+                <span className="font-bold text-[14px]">이메일</span>
                 <div className="pl-[10px]">
                   <span className="text-black01">{myPageInfo?.email}</span>
                 </div>
@@ -238,7 +251,7 @@ const MyPage = () => {
 
               {/* 소속 */}
               <div className="flex flex-col gap-[5px]">
-                <span className="font-bold">소속</span>
+                <span className="font-bold text-[14px]">소속</span>
                 <input
                   type="text"
                   value={companyInfo}
@@ -256,14 +269,20 @@ const MyPage = () => {
               text="수정하기"
               size="md"
               css="bg-main-green01 border border-main-green text-main-beige01"
-              onClick={() => editMyInfo()}
+              onClick={() => {
+                if (!name.trim().length || !companyInfo.trim().length) {
+                  openModal("이름과 소속은 필수로 입력해야 됩니다!");
+                  return;
+                }
+                editMyInfo();
+              }}
             />
-            <Button
+            {/* <Button
               text="탈퇴하기"
               size="md"
               css="border-none text-[12px] text-main-green01"
               onClick={() => setIsConfirmModal(true)}
-            />
+            /> */}
           </div>
         </div>
       </div>
@@ -285,6 +304,11 @@ const MyPage = () => {
             setIsModal={setEditSuccessModalOpen}
             css="animate-fadeUp"
           />
+        </div>
+      )}
+      {isModalOpen && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/30 z-50">
+          <AlertModal text={modalText} onClose={closeModal} />
         </div>
       )}
     </section>

--- a/src/pages/SignUpCompanyInfo.tsx
+++ b/src/pages/SignUpCompanyInfo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "../components/common/Button";
 import defaultImg from "../assets/defaultImg.svg";
 import { useAuthStore } from "../store/authStore";
@@ -8,9 +8,11 @@ import AlertModal from "../components/common/AlertModal";
 
 const SignUpCompanyInfo = () => {
   const [companyInfo, setCompanyInfo] = useState<string | undefined>("");
-  const [profileImg, setProfileImg] = useState<string | null>(defaultImg);
+  const [profileImg, setProfileImg] = useState<string | null>(null);
   const [userName, setUserName] = useState<string>("");
   const [isHovered, setIsHovered] = useState<boolean>(false);
+  const [isFileDialogOpen, setIsFileDialogOpen] = useState(false);
+
   const { login, idToken } = useAuthStore();
   const navigate = useNavigate();
 
@@ -126,7 +128,21 @@ const SignUpCompanyInfo = () => {
       };
 
       reader.readAsDataURL(file);
+      setIsFileDialogOpen(false);
     }
+  };
+
+  useEffect(() => {
+    if (!isFileDialogOpen) {
+      setTimeout(() => {
+        setIsHovered(false);
+      }, 200);
+    }
+  }, [isFileDialogOpen]);
+
+  const handleFileInputClick = () => {
+    setIsHovered(true);
+    setIsFileDialogOpen(true);
   };
 
   return (
@@ -151,7 +167,7 @@ const SignUpCompanyInfo = () => {
           <div
             className="relative w-full h-full rounded-[5px]"
             onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
+            onMouseLeave={() => !isFileDialogOpen && setIsHovered(false)}
           >
             <img
               src={profileImg || defaultImg}
@@ -169,11 +185,15 @@ const SignUpCompanyInfo = () => {
                 {/* 이미지 변경 버튼 */}
                 <div
                   className="text-gray02 hover:text-white cursor-pointer
-                      bg-main-green/30 hover:bg-main-green px-[10px] py-[5px] 
+                      bg-main-green/30 hover:bg-main-green w-[94px] h-[35px] 
                       rounded-[5px]"
-                  onClick={() => document.getElementById("fileInput")?.click()}
                 >
-                  <p>이미지 변경</p>
+                  <label
+                    className="w-full h-full flex items-center justify-center cursor-pointer"
+                    htmlFor="fileInput"
+                  >
+                    이미지 변경
+                  </label>
 
                   {/* 파일 업로드 입력 (숨김) */}
                   <input
@@ -182,11 +202,12 @@ const SignUpCompanyInfo = () => {
                     accept="image/*"
                     className="hidden"
                     onChange={handleProfileImg}
+                    onClick={handleFileInputClick}
                   />
                 </div>
 
                 {/* 기본 이미지 버튼 */}
-                {profileImg !== defaultImg && (
+                {profileImg !== null && (
                   <div
                     className="w-fit text-center px-[10px] py-[5px] cursor-pointer
                       text-[14px] font-bold text-white hover:text-main-green01
@@ -202,9 +223,9 @@ const SignUpCompanyInfo = () => {
         </div>
 
         {/* 개인 정보란 */}
-        <div className="flex flex-col justify-between gap-[10px]">
+        <div className="flex flex-col justify-center gap-[10px]">
           <div className="flex flex-col gap-[5px]">
-            <p className="font-bold">이름</p>
+            <p className="font-bold text-[14px]">이름</p>
             <input
               type="text"
               value={userName ?? ""}
@@ -214,13 +235,7 @@ const SignUpCompanyInfo = () => {
             />
           </div>
           <div className="flex flex-col gap-[5px]">
-            <p className="font-bold">이메일</p>
-            <div className="pl-[10px]">
-              <p className="text-black01">hong@gmail.com</p>
-            </div>
-          </div>
-          <div className="flex flex-col gap-[5px]">
-            <p className="font-bold">소속</p>
+            <p className="font-bold text-[14px]">소속</p>
             <input
               type="text"
               value={companyInfo ?? ""}

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -23,7 +23,7 @@ interface AccountListProps {
 }
 
 interface EditAccountType {
-  newName: string;
+  name: string;
 }
 
 interface AdminProjectsListType {


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 마이페이지 기본이미지 적용 오류 수정했습니다.
- 사용자가 이름과 소속만 변경한다면 이미지 파일은 formdata에 추가되지 않습니다.
- 사용자가 기본이미지로 변경한다면 이미지 파일은 빈 파일형식으로 보냅니다.

- 회원 등록하기 부분에서 이메일제거 했습니다.
- 회원 등록하기/마이페이지 에서 label 부분 폰트 크기 조정했습니다

- 관리자 계정 수정 요청값 newName -> name으로 변경했습니다.
## 🔗 관련 이슈

#247 

## 📸 스크린샷 (선택)

<img width="303" alt="스크린샷 2025-03-08 오후 11 21 20" src="https://github.com/user-attachments/assets/e3f3fd99-b7d3-4326-9fda-4f91de13b2b7" />

