### PR TITLE
Feat 경고창 toast UI 변경 #254

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-cookie": "^7.2.2",
     "react-router": "^7.1.5",
+    "react-toastify": "^11.0.5",
     "sockjs-client": "^1.6.1",
     "tailwind-merge": "^3.0.1",
     "tailwind-scrollbar": "^4.0.0",

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,3 +1,4 @@
+import { showToast } from "../utils/toastConfig";
 import { api } from "./api";
 
 // 관리자 대시보드
@@ -33,6 +34,11 @@ export const editAdminAccount = async (
       editAccountInfo
     );
     console.log(response);
+    if (response.status === 200) {
+      showToast("success", "계정 이름이 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -58,6 +64,9 @@ export const deleteAdminAccount = async (member_id: number) => {
       `/admin/manage/member/${member_id}/delete`
     );
     console.log(response);
+    if (response.status !== 204) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.log(error);
@@ -71,6 +80,9 @@ export const adminRestoreAccount = async (memberId: number) => {
       `/admin/manage/member/${memberId}/activate`
     );
     console.log(response);
+    if (response.status !== 200) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -112,6 +124,11 @@ export const adminEditProject = async (
       editInfo
     );
     console.log("editAdminProject", response);
+    if (response.status === 200) {
+      showToast("success", "프로젝트가 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -125,6 +142,9 @@ export const adminDeleteProject = async (projectId: number) => {
       `/admin/manage/project/${projectId}/delete`
     );
     console.log("adminDeleteProject", response);
+    if (response.status !== 204) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -138,6 +158,9 @@ export const adminRestoreProject = async (projectId: number) => {
       `/admin/manage/project/${projectId}/activate`
     );
     console.log(response);
+    if (response.status !== 200) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -171,11 +194,16 @@ export const getAdminDeleteTaskList = async () => {
 // 관리자 업무 수정
 export const updateTask = async (taskId: number, editTaskInfo: UpdatedTask) => {
   try {
-    const { data } = await api.put(
+    const { data, status } = await api.put(
       `/admin/manage/task/${taskId}/modify`,
       editTaskInfo
     );
     console.log("업무 수정 성공", data);
+    if (status === 200) {
+      showToast("success", "업무가 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return data;
   } catch (error) {
     console.error("업무 수정 실패", error);
@@ -185,8 +213,13 @@ export const updateTask = async (taskId: number, editTaskInfo: UpdatedTask) => {
 // 관리자 업무 삭제
 export const deleteTask = async (taskId: number) => {
   try {
-    const { data } = await api.delete(`/admin/manage/task/${taskId}/delete`);
+    const { data, status } = await api.delete(
+      `/admin/manage/task/${taskId}/delete`
+    );
     console.log("업무 삭제 성공", data);
+    if (status !== 204) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return data;
   } catch (error) {
     console.error("업무 삭제 실패", error);
@@ -198,6 +231,9 @@ export const adminRestoreTask = async (taskId: number) => {
   try {
     const response = await api.patch(`/admin/manage/task/${taskId}/activate`);
     console.log(response);
+    if (response.status !== 200) {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);

--- a/src/api/adminCategory.ts
+++ b/src/api/adminCategory.ts
@@ -1,3 +1,4 @@
+import { showToast } from "../utils/toastConfig";
 import { api } from "./api";
 
 // 관리자 카테고리 전체 조회
@@ -36,8 +37,10 @@ export const adminEditCategory = async (
       }
     );
     console.log(response);
-    if (response.status === 204) {
-      alert("카테고리 수정이 완료되었습니다.");
+    if (response.status === 200) {
+      showToast("success", "카테고리 수정이 완료되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
     }
     return response;
   } catch (error) {
@@ -53,7 +56,9 @@ export const adminDeleteCategory = async (categoryId: number) => {
     );
     console.log("adminDeleteCategory", response);
     if (response.status === 204) {
-      alert("카테고리가 삭제되었습니다");
+      showToast("success", "카테고리가 삭제되었습니다");
+    } else {
+      showToast("error", "에러가 발생했습니다");
     }
     return response;
   } catch (error) {

--- a/src/api/adminDetailTag.ts
+++ b/src/api/adminDetailTag.ts
@@ -1,3 +1,4 @@
+import { showToast } from "../utils/toastConfig";
 import { api } from "./api";
 
 // 관리자 상세항목 태그 생성
@@ -13,6 +14,11 @@ export const adminAddnewDetailTag = async (
       }
     );
     console.log("adminAddnewDetailTag", response);
+    if (response.status === 200) {
+      showToast("success", "상세항목이 추가되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
 
     return response;
   } catch (error) {
@@ -35,7 +41,9 @@ export const adminEditDetailTag = async (
     );
     console.log("adminEditDetailTag", response);
     if (response.status === 200) {
-      alert("태그가 수정되었습니다");
+      showToast("success", "상세항목이 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
     }
     return response;
   } catch (error) {
@@ -52,11 +60,14 @@ export const adminDeleteDetailTag = async (
     const response = await api.delete(
       `/admin/manage/subcategory/${subcategoryId}/tag/${tagId}/delete`
     );
-    console.log("adminDeleteDetailTag", response);
-    if (response.status === 204) {
-      alert("상세항목 태그 삭제가 완료되었습니다");
-    }
 
+    console.log("adminDeleteDetailTag", response);
+
+    if (response.status === 204) {
+      showToast("success", "상세항목이 삭제되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);

--- a/src/api/adminSubCategory.ts
+++ b/src/api/adminSubCategory.ts
@@ -1,3 +1,4 @@
+import { showToast } from "../utils/toastConfig";
 import { api } from "./api";
 
 // 관리자 서브카테고리 생성
@@ -11,6 +12,11 @@ export const adminAddNewSubCategory = async (
       { name: newName }
     );
     console.log("adminAddNewSubCategory", response);
+    if (response.status === 201) {
+      showToast("success", "세부항목이 추가되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -28,7 +34,11 @@ export const adminEditSubCategory = async (
       { name: editSubCateName }
     );
     console.log("adminEditSubCategory", response);
-
+    if (response.status === 200) {
+      showToast("success", "세부항목이 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error(error);
@@ -43,7 +53,9 @@ export const adminDeleteSubCategory = async (subcategoryId: number) => {
     );
     console.log("adminDeleteSubCategory", response);
     if (response.status === 204) {
-      alert("서브카테고리 삭제가 완료되었습니다");
+      showToast("success", "세부항목이 삭제되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
     }
     return response;
   } catch (error) {

--- a/src/api/project.ts
+++ b/src/api/project.ts
@@ -1,3 +1,4 @@
+import { showToast } from "../utils/toastConfig";
 import { api } from "./api";
 
 // 프로젝트 리스트 정보 가져오는 API
@@ -16,7 +17,12 @@ export const getProjectList = async () => {
 export const postProject = async (projectData: postProjectType) => {
   try {
     const response = await api.post("/api/projects/create", projectData);
-    console.log("생성된 프로젝트:", response.data);
+    console.log("생성된 프로젝트:", response);
+    if (response.status === 201) {
+      showToast("success", "프로젝트가 생성되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response.data;
   } catch (error) {
     console.error("프로젝트 생성 실패:", error);
@@ -50,11 +56,18 @@ export const patchProjectById = async (
       `/api/projects/${projectId}/update`,
       updateData
     );
-    console.log("프로젝트 수정 성공", response.data);
+    console.log("프로젝트 수정 성공", response);
+    if (response.status === 204) {
+      showToast("success", "프로젝트가 수정되었습니다.");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response.data;
   } catch (error: any) {
     console.error("프로젝트 수정 오류", error);
-    Object.values(error.response.data).forEach((value) => alert(value));
+    Object.values(error.response.data as string).forEach((value: string) =>
+      showToast("error", value)
+    );
     throw new Error("프로젝트 수정하기 오류");
   }
 };
@@ -76,6 +89,11 @@ export const deleteProject = async (projectId: number) => {
   try {
     const response = await api.delete(`/api/projects/${projectId}/delete`);
     console.log("프로젝트 삭제:", response);
+    if (response.status === 204) {
+      showToast("success", "프로젝트가 삭제되었습니다!");
+    } else {
+      showToast("error", "에러가 발생했습니다.");
+    }
     return response;
   } catch (error) {
     console.error("Error project delete:", error);

--- a/src/components/Admin/Account/AdminAccount.tsx
+++ b/src/components/Admin/Account/AdminAccount.tsx
@@ -18,6 +18,7 @@ import {
 import { queryClient } from "../../../main";
 import { searchAllMembers } from "../../../api/search";
 import AlertModal from "../../common/AlertModal";
+import { showToast } from "../../../utils/toastConfig";
 
 const AdminAccount = () => {
   // 활성 멤버 데이터
@@ -189,7 +190,7 @@ const AdminAccount = () => {
 
     // 삭제 확인 모달 띄우기
     openModal(
-      `정말 ${checkedAccountIds.length}명의 유저를 삭제하시겠습니까?`,
+      `정말 ${checkedAccountIds.length}개의 계정을 삭제하시겠습니까?`,
       async () => {
         await Promise.all(
           checkedAccountIds.map((id) => {
@@ -200,7 +201,10 @@ const AdminAccount = () => {
         setIsCheckedAll(false);
         setCheckedAccountIds([]);
 
-        alert("유저가 삭제되었습니다");
+        showToast(
+          "success",
+          `${checkedAccountIds.length}개의 계정이 삭제되었습니다`
+        );
       }
     );
   };
@@ -231,7 +235,10 @@ const AdminAccount = () => {
         setCheckedAccountIds([]);
         setIsCheckedAll(false);
 
-        alert("유저를 복구했습니다.");
+        showToast(
+          "success",
+          `${checkedAccountIds.length}개의 계정이 복구되었습니다`
+        );
       }
     );
   };

--- a/src/components/Admin/Project/AdminProject.tsx
+++ b/src/components/Admin/Project/AdminProject.tsx
@@ -19,6 +19,7 @@ import AdminDeleteBtn from "../Button/AdminDeleteBtn";
 import { queryClient } from "../../../main";
 import { searchProjects } from "../../../api/search";
 import AlertModal from "../../common/AlertModal";
+import { showToast } from "../../../utils/toastConfig";
 
 const AdminProject = () => {
   const { data: adminActiveProject } = useQuery<AdminProjectsListType[]>({
@@ -159,6 +160,10 @@ const AdminProject = () => {
       async () => {
         await Promise.all(checkedIds.map((id) => deleteProjectFn(id))); // 병렬 실행
         closeModal();
+        showToast(
+          "success",
+          `${checkedIds.length}개의 프로젝트가 삭제되었습니다.`
+        );
       }
     );
   };
@@ -179,7 +184,7 @@ const AdminProject = () => {
       queryClient.invalidateQueries({ queryKey: ["AdminInAcitveProject"] });
       setIsAllChecked(false);
       setCheckedIds([]);
-      openModal("프로젝트가 삭제되었습니다");
+      // openModal("프로젝트가 삭제되었습니다");
     },
   });
 
@@ -206,7 +211,10 @@ const AdminProject = () => {
       async () => {
         await Promise.all(checkedIds.map((id) => restoreProject(id)));
         closeModal();
-        alert("프로젝트를 복구했습니다.");
+        showToast(
+          "success",
+          `${checkedIds.length}개의 프로젝트가 복구되었습니다.`
+        );
       }
     );
   };

--- a/src/components/Admin/Tag/AdminTag.tsx
+++ b/src/components/Admin/Tag/AdminTag.tsx
@@ -9,6 +9,7 @@ import AdminTagBox from "./AdminTagBox";
 import { adminAddNewSubCategory } from "../../../api/adminSubCategory";
 import { adminAddnewDetailTag } from "../../../api/adminDetailTag";
 import { queryClient } from "../../../main";
+import { showToast } from "../../../utils/toastConfig";
 
 const AdminTag = () => {
   const { data: allCategories } = useQuery<AllCategoryType[]>({
@@ -20,12 +21,11 @@ const AdminTag = () => {
 
   const [details2, setDetails2] = useState<{ id: number; name: string }[]>([]);
 
-  const [categoryId, setCategoryId] = useState<number>();
-  const [subCategoryId, setSubCategoryId] = useState<number>();
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [subCategoryId, setSubCategoryId] = useState<number | null>(null);
 
   useEffect(() => {
-    if (allCategories && isCategoryClicked) {
-      console.log("allCategories");
+    if (allCategories && isCategoryClicked !== null) {
       setSubCategories2(allCategories[isCategoryClicked].subcategories);
     }
   }, [allCategories]);
@@ -67,6 +67,7 @@ const AdminTag = () => {
     mutationFn: (newCategoryName: string) => adminNewCategory(newCategoryName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["AllCategory"] });
+      showToast("success", "분야가 추가되었습니다");
       setIsAddCategory(false);
     },
   });
@@ -80,7 +81,8 @@ const AdminTag = () => {
 
   const handleAddSubcategory = () => {
     if (subCategories2.length === 2) {
-      return alert("세부항목은 최대 2개까지 생성이 가능합니다");
+      showToast("error", "세부항목은 최대 2개까지 생성이 가능합니다");
+      return;
     }
     setIsAddSubCategory(true);
   };
@@ -127,8 +129,24 @@ const AdminTag = () => {
     },
   });
 
-  const [isCategoryClicked, setIsCategoryClicked] = useState<number | null>();
-  const [isSubCateClicked, setIsSubCateClicked] = useState<number | null>();
+  const [isCategoryClicked, setIsCategoryClicked] = useState<number | null>(
+    null
+  );
+  const [isSubCateClicked, setIsSubCateClicked] = useState<number | null>(null);
+
+  useEffect(() => {
+    setSubCategoryId(null);
+    console.log("as");
+    if (isCategoryClicked === null) {
+      setIsSubCateClicked(null);
+      setSubCategories2([]);
+      setDetails2([]);
+    }
+  }, [isCategoryClicked]);
+
+  useEffect(() => {
+    console.log(subCategoryId);
+  }, [subCategoryId]);
 
   return (
     <div className="h-[calc(100vh-50px)] bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0">
@@ -237,7 +255,7 @@ const AdminTag = () => {
             </span>
 
             <div className="flex w-full justify-end h-[27px]">
-              {subCategoryId && (
+              {subCategoryId !== null && (
                 <button onClick={handleAddDetail} className="cursor-pointer">
                   <img src={AddButton} alt="상세항목 생성 버튼" />
                 </button>

--- a/src/components/Admin/Tag/AdminTagAdd.tsx
+++ b/src/components/Admin/Tag/AdminTagAdd.tsx
@@ -5,8 +5,8 @@ import AdminEditCancelBtn from "../Button/AdminEditCancelBtn";
 interface AdminTagAddProps {
   index: number;
   onClick?: (newCategoryName: string) => void;
-  categoryId?: number;
-  subcategoryId?: number;
+  categoryId?: number | null;
+  subcategoryId?: number | null;
   addSubCategory?: (categoryId: number, newSubCategoryName: string) => void;
   setIsAdd: React.Dispatch<React.SetStateAction<boolean>>;
   addType: string;

--- a/src/components/Admin/Tag/AdminTagList.tsx
+++ b/src/components/Admin/Tag/AdminTagList.tsx
@@ -23,14 +23,13 @@ interface AdminTagListProps {
   index: number;
   name: string;
   id: number;
-  subcategoryId?: number;
+  subcategoryId?: number | null;
   onClick: (categoryIndex: number, categoryId: number) => void;
   type: "category" | "subCategory" | "detailTags";
   isClicked?: number | null;
-  setIsClicked?: React.Dispatch<
-    React.SetStateAction<number | null | undefined>
-  >;
+  setIsClicked?: React.Dispatch<React.SetStateAction<number | null>>;
   setDetails2?: React.Dispatch<React.SetStateAction<any[]>>;
+  setSubCategories2?: React.Dispatch<React.SetStateAction<SubCategoryType[]>>;
 }
 
 const AdminTagList = ({
@@ -50,8 +49,12 @@ const AdminTagList = ({
   // 카테고리 삭제함수
   const { mutate: deleteCategoryFn } = useMutation({
     mutationFn: (categoryId: number) => adminDeleteCategory(categoryId),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["AllCategory"] }),
+    onSuccess: () => {
+      if (setIsClicked) {
+        setIsClicked(null);
+      }
+      queryClient.invalidateQueries({ queryKey: ["AllCategory"] });
+    },
   });
 
   // 카테고리 수정함수
@@ -90,7 +93,6 @@ const AdminTagList = ({
       editSubCateName: string;
     }) => {
       await adminEditSubCategory(subcategoryId, editSubCateName);
-
       setIsEditable(false);
     },
     onSuccess: () =>
@@ -162,6 +164,7 @@ const AdminTagList = ({
   return (
     <div
       onClick={() => {
+        if (isClicked === index) return;
         onClick(index, id);
         if (setIsClicked) {
           setIsClicked(index);

--- a/src/components/Admin/Task/AdminTask.tsx
+++ b/src/components/Admin/Task/AdminTask.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../api/admin";
 import ConfirmModal from "../../modals/ConfirmModal";
 import { queryClient } from "../../../main";
+import { showToast } from "../../../utils/toastConfig";
 
 export interface TasksListType {
   id: number;
@@ -120,7 +121,10 @@ const AdminTask = () => {
       // 삭제 요청 실행 (모든 삭제 요청이 완료될 때까지 대기)
       await Promise.all(isCheckedTask.map((taskId) => deleteTaskFn(taskId)));
 
-      console.log("삭제 완료");
+      showToast(
+        "success",
+        `${isCheckedTask.length}개의 업무가 삭제되었습니다.`
+      );
 
       // 삭제 요청이 성공한 후 상태 업데이트
       setDeleteTasks((prevTasks) =>
@@ -190,12 +194,9 @@ const AdminTask = () => {
       console.log("선택된 업무가 없습니다.");
       return;
     }
-
-    console.log(isCheckedTask);
-    // 삭제 요청 실행 (모든 삭제 요청이 완료될 때까지 대기)
     await Promise.all(isCheckedTask.map((taskId) => restoreTask(taskId)));
     setIsCheckedTask([]);
-    alert("복구완료");
+    showToast("success", `${isCheckedTask.length}개의 업무가 복구되었습니다.`);
     console.log("복구 완료");
   };
 

--- a/src/components/MainPage/Calendar.tsx
+++ b/src/components/MainPage/Calendar.tsx
@@ -10,10 +10,10 @@ import { EventDropArg, EventInput } from "@fullcalendar/core/index.js";
 import { useNavigate } from "react-router";
 import { getProjectList } from "../../api/project";
 import { useAuthStore } from "../../store/authStore";
-import AlertModal from "../common/AlertModal";
 import { getAssignedTaskList } from "../../api/task";
 import { CALENDAR_COLORS } from "../../constants/calendarColors";
 import { dragChangeTask } from "../../utils/calendar/dragChangeTask";
+import { showToast } from "../../utils/toastConfig";
 
 interface CalendarProps {
   refetch: () => void;
@@ -45,20 +45,6 @@ const Calendar = ({ refetch }: CalendarProps) => {
 
   const navigate = useNavigate();
   const loginUser = useAuthStore((state) => state.member);
-
-  // 모달 적용
-  const [modalText, setModalText] = useState<string>("");
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const openModal = (text: string) => {
-    setModalText(text);
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setModalText("");
-    setIsModalOpen(false);
-  };
 
   // 랜덤 색상 함수
   const getRandomColor = () => {
@@ -211,17 +197,15 @@ const Calendar = ({ refetch }: CalendarProps) => {
         editable={true}
         droppable={true}
         eventDrop={(info: EventDropArg) => {
-          if (!showTasks) {
-            if (loginUser?.id !== info.event.extendedProps.creatorId) {
-              openModal("프로젝트 생성자만 수정할 수 있습니다");
-              info.revert();
-              return;
-            }
-          }
           if (showTasks) {
             mutateTask(info);
             refetch();
           } else {
+            if (loginUser?.id !== info.event.extendedProps.creatorId) {
+              showToast("error", "프로젝트 생성자만 수정할 수 있습니다");
+              info.revert();
+              return;
+            }
             mutate(info);
             refetch();
           }
@@ -238,11 +222,6 @@ const Calendar = ({ refetch }: CalendarProps) => {
           refetch();
         }}
       />
-      {isModalOpen && (
-        <div className="fixed inset-0 flex items-center justify-center bg-black/30 z-50">
-          <AlertModal text={modalText} onClose={closeModal} />
-        </div>
-      )}
     </>
   );
 };

--- a/src/components/ProjectRoom/ProjectListBox.tsx
+++ b/src/components/ProjectRoom/ProjectListBox.tsx
@@ -23,10 +23,8 @@ const ProjectListBox = ({
   const [isEditProjectModal, setIsEditProjectModal] = useState<boolean>(false);
   // 프로젝트 나가기 모달
   const [isLeaveModal, setIsLeaveModal] = useState<boolean>(false);
-  console.log(projectInfo);
 
   const loginUser = useAuthStore((state) => state.member);
-  console.log(loginUser);
 
   const ISCREATED_BY_LOGINUSER = loginUser?.id === projectInfo.creatorId;
 

--- a/src/components/common/AlertModal.tsx
+++ b/src/components/common/AlertModal.tsx
@@ -12,7 +12,7 @@ const AlertModal = ({
   return (
     <div
       className="w-[423px]] h-[174px] bg-white px-[100px] py-[50px]
-  flex flex-col justify-center items-center gap-[30px]"
+  flex flex-col justify-center items-center gap-[30px] rounded-[5px]"
       onClick={(e) => e.stopPropagation()}
     >
       <p className="text-header-red font-bold">{text}</p>

--- a/src/components/modals/EditProjectModal.tsx
+++ b/src/components/modals/EditProjectModal.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router";
 import { progressType } from "../../utils/progressType";
 import { PROGRESS_STATUS } from "../../constants/status";
 import SimpleAlertModal from "./SimpleAlertModal";
+import { queryClient } from "../../main";
 
 const EDIT_MODAL_STATUS = ["진행 완료", "진행 중", "진행 예정"];
 
@@ -225,6 +226,10 @@ const EditProjectModal = ({
       selectedProject: ProjectListType;
       editProjectInfo: patchProjectRequestType;
     }) => patchProjectById(selectedProject.id, editProjectInfo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ProjectRoomList"] });
+      setIsEditProjectModal(false);
+    },
   });
 
   const editProject = async (
@@ -236,7 +241,6 @@ const EditProjectModal = ({
       editProjectInfo,
     });
     console.log(response);
-    navigate(0);
   };
 
   return (

--- a/src/components/modals/SimpleAlertModal.tsx
+++ b/src/components/modals/SimpleAlertModal.tsx
@@ -14,7 +14,7 @@ const SimpleAlertModal = ({
     <div
       className={twMerge(
         `bg-white text-main-green px-[100px] py-[50px] gap-[30px]
-  flex flex-col justify-center items-center z-10`,
+  flex flex-col justify-center items-center z-10 rounded-[5px]`,
         css
       )}
       onClick={(e) => e.stopPropagation()}

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,25 @@
 .scrollbar::-webkit-scrollbar-track {
   background: #e8e8e800;
 }
+
+/* react- toastify */
+.Toastify__toast {
+  background-color: #fff6e9;
+  font-size: 14px;
+}
+
+.Toastify__toast--error {
+  background-color: #ff1e0092;
+  /* color: rgb(242, 242, 242); */
+  color: #232b24;
+}
+
+.Toastify__progress-bar--success {
+  /* color: white; */
+  background-color: #465448;
+}
+
+:root {
+  --toastify-icon-color-success: #465448;
+  --toastify-icon-color-error: #ff1d00;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ToastContainer } from "react-toastify";
 
 export const queryClient = new QueryClient();
 
@@ -13,6 +14,7 @@ createRoot(document.getElementById("root")!).render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
+        <ToastContainer />
         <App />
       </QueryClientProvider>
     </BrowserRouter>

--- a/src/utils/calendar/dragChange.ts
+++ b/src/utils/calendar/dragChange.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import { api } from "../../api/api";
 import { EventDropArg } from "@fullcalendar/core/index.js";
+import { showToast } from "../toastConfig";
 
 // 캘린더 일정 드래그시 호출함수
 export const dragChange = async (info: EventDropArg) => {
@@ -21,11 +22,15 @@ export const dragChange = async (info: EventDropArg) => {
       membersIds: projectData.memberIds,
     });
     console.log(response);
+    if (response.status === 204) {
+      showToast("success", "프로젝트 일정이 수정되었습니다");
+    }
     return response;
   } catch (error: any) {
     console.error(error.response.data);
-    Object.values(error.response.data).forEach((value) => alert(value));
-    // alert("에러가 발생했습니다.");
+    Object.values(error.response.data).forEach((value) =>
+      showToast("error", value as string)
+    );
     info.revert();
   }
 };

--- a/src/utils/calendar/dragChangeTask.ts
+++ b/src/utils/calendar/dragChangeTask.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import { api } from "../../api/api";
 import { EventDropArg } from "@fullcalendar/core/index.js";
+import { showToast } from "../toastConfig";
 
 // 캘린더 일정 드래그시 호출함수
 export const dragChangeTask = async (info: EventDropArg) => {
@@ -29,10 +30,15 @@ export const dragChangeTask = async (info: EventDropArg) => {
       participantIds: [projectData.assignedMemberId],
     });
     console.log(response);
+    if (response.status === 200) {
+      showToast("success", "업무 일정이 변경되었습니다.");
+    }
     return response;
   } catch (error: any) {
     console.error(error.response.data);
-    Object.values(error.response.data).forEach((value) => alert(value));
+    Object.values(error.response.data).forEach((value) =>
+      showToast("error", value as string)
+    );
     // alert("에러가 발생했습니다.");
     info.revert();
   }

--- a/src/utils/toastConfig.ts
+++ b/src/utils/toastConfig.ts
@@ -1,0 +1,18 @@
+import { toast, ToastOptions, Zoom } from "react-toastify";
+
+export const defaultToastOptions: ToastOptions = {
+  position: "top-center",
+  autoClose: 3000,
+  hideProgressBar: true,
+  closeOnClick: false,
+  pauseOnHover: false,
+  draggable: true,
+  transition: Zoom,
+};
+
+export const showToast = (
+  type: "success" | "error" | "info" | "warning",
+  message: string
+) => {
+  toast[type](message, defaultToastOptions);
+};


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- alert창 react-toastify로 변경했습니다.
- 기존에 모달로 뜨는 부분은 변경안했습니다.
- toast에서 현재는 success, error만 커스텀 디자인이 완료된 상태 입니다.
- 사소한 버그도 함께 수정했습니다.

- toast를 사용하실 때 toastConfig.ts에 있는 showToast 함수 사용하시면 됩니다.
- showToast() 에서 첫 번째는 toast의 타입 success, error 또는 다른 타입을 작성하시고 두 번째로 띄울 메시지값을 string으로 넣으면 됩니다.

## 🔗 관련 이슈

#254 

## 📸 스크린샷 (선택)
<img width="376" alt="스크린샷 2025-03-09 오후 3 07 47" src="https://github.com/user-attachments/assets/35c6c743-7032-4413-9e8b-57ce351d869a" />

<img width="373" alt="스크린샷 2025-03-09 오후 3 07 56" src="https://github.com/user-attachments/assets/bae3c872-466a-42da-8e88-f06a62b5f30e" />
