### PR TITLE
<Merge/feat_미팅룸-웹소켓-구독-관련_#257>feat:미팅룸웹소켓전역변경 #257

### DIFF
--- a/src/components/ProjectRoom/ProjectListBox.tsx
+++ b/src/components/ProjectRoom/ProjectListBox.tsx
@@ -11,7 +11,6 @@ import { useMutation } from "@tanstack/react-query";
 import { deleteProject, leaveProject } from "../../api/project";
 import { queryClient } from "../../main";
 import AlertModal from "../common/AlertModal";
-import defaultProfileImg from "../../assets/defaultImg.svg";
 
 const ProjectListBox = ({
   projectId,

--- a/src/store/useWebSocketStore.ts
+++ b/src/store/useWebSocketStore.ts
@@ -44,7 +44,7 @@ const useWebSocketStore = create<WebSocketStore>((set, get) => {
         return;
       }
 
-      console.log("웹소켓 연결 시도...");
+      console.log("알람 웹소켓 연결 시도...");
 
       const socket = new SockJS(`${import.meta.env.VITE_API_URL}/ws`);
       const client = new Client({
@@ -54,7 +54,7 @@ const useWebSocketStore = create<WebSocketStore>((set, get) => {
           Authorization: `Bearer ${accessToken}`,
         },
         onConnect: () => {
-          console.log("STOMP 클라이언트 연결됨");
+          console.log("STOMP 클라이언트 연결됨(알람)");
           set({ isConnected: true, stompClient: client });
 
           setTimeout(() => {
@@ -79,7 +79,7 @@ const useWebSocketStore = create<WebSocketStore>((set, get) => {
     subscribeToNotifications: (memberId: number) => {
       const { stompClient } = get();
       if (!stompClient) {
-        console.warn(" STOMP 클라이언트가 아직 활성화되지 않았음.");
+        console.warn(" STOMP 클라이언트가 아직 활성화되지 않았음(알람)");
         return;
       }
 


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

미팅룸 웹소켓 연결을 컴포넌트에서 개별적으로 관리하고 있었음.
미팅룸의 타입이 변경될 때(예: meeting-room/3 → project-room/3?category=meeting) 새로고침하지 않으면 WebSocket 구독이 안 되는 문제 발생.
알람 웹소켓(전역 상태로 관리됨)과 충돌하여 채팅 웹소켓 구독이 정상적으로 되지 않는 현상이 있었음.

- 웹소켓 연결은 전역 연결을 함께 쓰고, 미팅룸 컴포넌트에서는 채팅 웹소켓 구독만 하도록 수정하여 
다른 미팅룸 타입으로 이동했을 때 웹소켓 연결이 안되는 문제 해결했습니다.

## 🔗 관련 이슈

- #257

## 📸 스크린샷 (선택)

UI 변경이 있다면 스크린샷을 첨부해주세요.
