### PR TITLE
feat: 대그데이터 그래프 구현 #259

### DIFF
--- a/src/components/Admin/Tag/AdminTag.tsx
+++ b/src/components/Admin/Tag/AdminTag.tsx
@@ -10,6 +10,8 @@ import { adminAddNewSubCategory } from "../../../api/adminSubCategory";
 import { adminAddnewDetailTag } from "../../../api/adminDetailTag";
 import { queryClient } from "../../../main";
 import { showToast } from "../../../utils/toastConfig";
+import AdminTagChart from "./AdminTagChart";
+import TagCountBox from "./TagCountBox";
 
 const AdminTag = () => {
   const { data: allCategories } = useQuery<AllCategoryType[]>({
@@ -148,6 +150,7 @@ const AdminTag = () => {
     console.log(subCategoryId);
   }, [subCategoryId]);
 
+  // 태그 목록
   return (
     <div className="h-[calc(100vh-50px)] bg-gradient-to-t from-white/0 via-[#BFCDB7]/30 to-white/0">
       <div className="min-h-[calc(100vh-80px)] mx-[30px] mb-[30px] px-[30px] pt-[30px] flex flex-col  bg-white/60">
@@ -170,140 +173,169 @@ const AdminTag = () => {
             />
           </div>
         </div>
-        <div className="flex w-full gap-[30px]">
-          <div className="flex flex-col w-full gap-[10px]">
-            <span className="font-bold text-[16px] text-main-green">분야</span>
-            <div className="flex w-full justify-end">
-              <button onClick={handleAddCategory} className="cursor-pointer">
-                <img src={AddButton} alt="분야 생성 버튼" />
-              </button>
-            </div>
-            <AdminTagBox name="분야" />
-            <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {allCategories?.map((category, index) => (
-                <AdminTagList
-                  key={category.id}
-                  index={index}
-                  id={category.id}
-                  name={category.name}
-                  isClicked={isCategoryClicked}
-                  setIsClicked={setIsCategoryClicked}
-                  onClick={categoryClick}
-                  type="category"
-                />
-              ))}
-              {isAddCategory && allCategories && (
-                <AdminTagAdd
-                  index={allCategories.length}
-                  onClick={(newCategoryName: string) =>
-                    addNewCategoryFn(newCategoryName)
-                  }
-                  setIsAdd={setIsAddCategory}
-                  addType="category"
-                />
-              )}
-            </div>
-          </div>
-          <div className="flex flex-col w-full gap-[10px]">
-            <span className="font-bold text-[16px] text-main-green">
-              세부항목
-            </span>
-
-            <div className="h-[27px] flex w-full justify-end">
-              {categoryId && (
-                <button
-                  onClick={handleAddSubcategory}
-                  className="cursor-pointer"
-                >
-                  <img src={AddButton} alt="세부항목 생성 버튼" />
+        {isTagList === "tagList" ? (
+          <div className="flex w-full gap-[30px]">
+            <div className="flex flex-col w-full gap-[10px]">
+              <span className="font-bold text-[16px] text-main-green">
+                분야
+              </span>
+              <div className="flex w-full justify-end">
+                <button onClick={handleAddCategory} className="cursor-pointer">
+                  <img src={AddButton} alt="분야 생성 버튼" />
                 </button>
-              )}
+              </div>
+              <AdminTagBox name="분야" />
+              <div className="h-[400px] overflow-y-scroll scrollbar-none">
+                {allCategories?.map((category, index) => (
+                  <AdminTagList
+                    key={category.id}
+                    index={index}
+                    id={category.id}
+                    name={category.name}
+                    isClicked={isCategoryClicked}
+                    setIsClicked={setIsCategoryClicked}
+                    onClick={categoryClick}
+                    type="category"
+                  />
+                ))}
+                {isAddCategory && allCategories && (
+                  <AdminTagAdd
+                    index={allCategories.length}
+                    onClick={(newCategoryName: string) =>
+                      addNewCategoryFn(newCategoryName)
+                    }
+                    setIsAdd={setIsAddCategory}
+                    addType="category"
+                  />
+                )}
+              </div>
             </div>
+            <div className="flex flex-col w-full gap-[10px]">
+              <span className="font-bold text-[16px] text-main-green">
+                세부항목
+              </span>
 
-            <AdminTagBox name="세부항목" />
-            <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {subCategories2.map((subcategory, index) => (
-                <AdminTagList
-                  key={subcategory.id}
-                  index={index}
-                  id={subcategory.id}
-                  name={subcategory.name}
-                  onClick={subCategoryClick}
-                  type="subCategory"
-                  isClicked={isSubCateClicked}
-                  setIsClicked={setIsSubCateClicked}
-                  setDetails2={setDetails2}
-                />
-              ))}
-              {isAddSubCategory && subCategories2 && (
-                <AdminTagAdd
-                  index={subCategories2.length}
-                  categoryId={categoryId}
-                  addSubCategory={(
-                    categoryId: number,
-                    newSubCategoryName: string
-                  ) => addNewSubCategory({ categoryId, newSubCategoryName })}
-                  setIsAdd={setIsAddSubCategory}
-                  addType="subCategory"
-                />
-              )}
+              <div className="h-[27px] flex w-full justify-end">
+                {categoryId && (
+                  <button
+                    onClick={handleAddSubcategory}
+                    className="cursor-pointer"
+                  >
+                    <img src={AddButton} alt="세부항목 생성 버튼" />
+                  </button>
+                )}
+              </div>
+
+              <AdminTagBox name="세부항목" />
+              <div className="h-[400px] overflow-y-scroll scrollbar-none">
+                {subCategories2.map((subcategory, index) => (
+                  <AdminTagList
+                    key={subcategory.id}
+                    index={index}
+                    id={subcategory.id}
+                    name={subcategory.name}
+                    onClick={subCategoryClick}
+                    type="subCategory"
+                    isClicked={isSubCateClicked}
+                    setIsClicked={setIsSubCateClicked}
+                    setDetails2={setDetails2}
+                  />
+                ))}
+                {isAddSubCategory && subCategories2 && (
+                  <AdminTagAdd
+                    index={subCategories2.length}
+                    categoryId={categoryId}
+                    addSubCategory={(
+                      categoryId: number,
+                      newSubCategoryName: string
+                    ) => addNewSubCategory({ categoryId, newSubCategoryName })}
+                    setIsAdd={setIsAddSubCategory}
+                    addType="subCategory"
+                  />
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col w-full gap-[10px]">
+              <span className="font-bold text-[16px] text-main-green">
+                상세항목
+              </span>
+
+              <div className="flex w-full justify-end h-[27px]">
+                {subCategoryId !== null && (
+                  <button onClick={handleAddDetail} className="cursor-pointer">
+                    <img src={AddButton} alt="상세항목 생성 버튼" />
+                  </button>
+                )}
+              </div>
+
+              <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
+                <div className="flex justify-center">
+                  <span>No.</span>
+                </div>
+                <div className="flex justify-center">
+                  <span>상세항목</span>
+                </div>
+                <div className="flex justify-center">
+                  <span>수정</span>
+                </div>
+                <div className="flex justify-center">
+                  <span>삭제</span>
+                </div>
+              </div>
+              <div className="h-[400px] overflow-y-scroll scrollbar-none">
+                {details2.map((detail, index) => (
+                  <AdminTagList
+                    key={detail.id}
+                    index={index}
+                    id={detail.id}
+                    name={detail.name}
+                    subcategoryId={subCategoryId}
+                    onClick={() => {}}
+                    type="detailTags"
+                    setDetails2={setDetails2}
+                  />
+                ))}
+                {isAddDetailTag && subCategoryId && (
+                  <AdminTagAdd
+                    index={details2.length}
+                    subcategoryId={subCategoryId}
+                    setIsAdd={setIsAddDetailTag}
+                    addType="detailTag"
+                    addDetailTag={(
+                      subcategoryId: number,
+                      newDetailTagName: string
+                    ) => addNewDetailTag({ subcategoryId, newDetailTagName })}
+                  />
+                )}
+              </div>
             </div>
           </div>
-          <div className="flex flex-col w-full gap-[10px]">
-            <span className="font-bold text-[16px] text-main-green">
-              상세항목
-            </span>
-
-            <div className="flex w-full justify-end h-[27px]">
-              {subCategoryId !== null && (
-                <button onClick={handleAddDetail} className="cursor-pointer">
-                  <img src={AddButton} alt="상세항목 생성 버튼" />
-                </button>
-              )}
+        ) : (
+          <div className="w-full">
+            <div className="flex gap-5 mb-[80px]">
+              <TagCountBox title="총 분야 수" count={allCategories?.length} />
+              <TagCountBox
+                title="총 세부항목 수"
+                count={allCategories?.reduce(
+                  (acc, category) => acc + category.subcategories.length,
+                  0
+                )}
+              />
+              <TagCountBox
+                title="총 상세항목 수"
+                count={allCategories?.reduce((acc, category) => {
+                  return (
+                    acc +
+                    category.subcategories.reduce((subAcc, subcategory) => {
+                      return subAcc + subcategory.tags.length;
+                    }, 0)
+                  );
+                }, 0)}
+              />
             </div>
-
-            <div className="grid grid-cols-[9.4%_1fr_12.5%_12.5%] w-full h-[33px] text-main-green border-b border-b-main-green">
-              <div className="flex justify-center">
-                <span>No.</span>
-              </div>
-              <div className="flex justify-center">
-                <span>상세항목</span>
-              </div>
-              <div className="flex justify-center">
-                <span>수정</span>
-              </div>
-              <div className="flex justify-center">
-                <span>삭제</span>
-              </div>
-            </div>
-            <div className="h-[400px] overflow-y-scroll scrollbar-none">
-              {details2.map((detail, index) => (
-                <AdminTagList
-                  key={detail.id}
-                  index={index}
-                  id={detail.id}
-                  name={detail.name}
-                  subcategoryId={subCategoryId}
-                  onClick={() => {}}
-                  type="detailTags"
-                  setDetails2={setDetails2}
-                />
-              ))}
-              {isAddDetailTag && subCategoryId && (
-                <AdminTagAdd
-                  index={details2.length}
-                  subcategoryId={subCategoryId}
-                  setIsAdd={setIsAddDetailTag}
-                  addType="detailTag"
-                  addDetailTag={(
-                    subcategoryId: number,
-                    newDetailTagName: string
-                  ) => addNewDetailTag({ subcategoryId, newDetailTagName })}
-                />
-              )}
-            </div>
+            <AdminTagChart />
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Admin/Tag/AdminTagChart.tsx
+++ b/src/components/Admin/Tag/AdminTagChart.tsx
@@ -1,0 +1,71 @@
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ChartOptions,
+} from "chart.js";
+import { searchTagCount } from "../../../api/search";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const AdminTagChart = () => {
+  const { data: tagCount, isLoading } = useQuery({
+    queryKey: ["adminTagCount"],
+    queryFn: searchTagCount,
+  });
+  useEffect(() => {
+    console.log(tagCount);
+  }, [tagCount]);
+
+  const data = {
+    labels: tagCount ? Object.keys(tagCount) : [],
+    datasets: [
+      {
+        label: "빈도 수",
+        data: tagCount ? Object.values(tagCount) : [],
+        backgroundColor: "#465448", // 바 색상
+        borderColor: "#465448",
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options: ChartOptions<"bar"> = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top", // 범례 위치
+      },
+      title: {
+        display: true,
+        text: "태그 빈도 수",
+      },
+    },
+  };
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-[600px]">
+        <div className="w-full h-full bg-gradient-to-r from-gray-300 via-gray-400 to-gray-300 animate-pulse rounded"></div>
+      </div>
+    );
+  }
+
+  return <Bar data={data} options={options} width={""} height={100} />;
+};
+
+export default AdminTagChart;

--- a/src/components/Admin/Tag/TagCountBox.tsx
+++ b/src/components/Admin/Tag/TagCountBox.tsx
@@ -1,0 +1,15 @@
+interface TagCountBoxProps {
+  title: string;
+  count: number | undefined;
+}
+
+const TagCountBox = ({ title, count }: TagCountBoxProps) => {
+  return (
+    <div className="border w-[300px] px-[10px] py-[5px] rounded-[10px] border-main-green01 shadow-md">
+      <p className="text-[14px]">{title}</p>
+      <p className="font-bold text-[22px]">{count}개</p>
+    </div>
+  );
+};
+
+export default TagCountBox;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,7 +10,7 @@ import DefaultImg from "../../assets/defaultImg.svg";
 const Header = () => {
   const navigate = useNavigate();
   const logout = useAuthStore((state) => state.logout);
-  const isAuthenticated = useAuthStore((state) => state.accessToken);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   // console.log(isAuthenticated);
 
   // console.log(isLogin);
@@ -157,7 +157,7 @@ const Header = () => {
                 onClick={() => {
                   logout();
                   useAuthStore.persist.clearStorage();
-                  navigate("/");
+                  navigate("/signin");
                 }}
               >
                 로그아웃

--- a/src/pages/ProtectedRoute.tsx
+++ b/src/pages/ProtectedRoute.tsx
@@ -2,7 +2,7 @@ import { Navigate, Outlet } from "react-router";
 import { useAuthStore } from "../store/authStore";
 
 const ProtectedRoute = () => {
-  const isAuthenticated = useAuthStore((state) => state.accessToken);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   return isAuthenticated ? <Outlet /> : <Navigate to="/signin" replace />;
 };

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -18,7 +18,6 @@ interface AuthState {
   registered?: boolean;
   // user: User | null;
   // login: (userData: User | null, token: null | string) => void;
-  user: any;
   login: (
     idToken: string | null,
     accessToken: string | null,
@@ -56,7 +55,6 @@ export const useAuthStore = create(
       //   set(() => {
       //     return { user: null, token: null, isAuthenticated: false };
       //   }),
-      user: null,
       login: (idToken, accessToken, refreshToken, member) =>
         set(() => ({
           idToken,
@@ -67,7 +65,7 @@ export const useAuthStore = create(
         })),
       logout: () =>
         set(() => {
-          return { user: null, accessToken: null, isAuthenticated: false };
+          return { member: null, accessToken: null, isAuthenticated: false };
         }),
       updateMember: (updateInfo: Partial<Member>) =>
         set((state) => ({


### PR DESCRIPTION
## ✅ 체크리스트

- merge할 브랜치의 위치를 확인해주세요 (main ❌)
- 리뷰어를 프론트 모든 팀원을 선택해주세요.
- PR의 라벨을 추가해주세요.

## ✨ 변경 사항

- 관리자 태그 데이터 그래프 구현했습니다.
- 총 분야, 세부항목, 상세항목 갯수 컴포넌트로 만들어서 표현했습니다.

- authStore에 오류가 있어서 수정했습니다.
- isAuthenticated 부분이 액세스토큰으로 구분을 해서 boolead값으로 변경했습니다.
- user부분 사용안해서 제거했습니다.

## 🔗 관련 이슈

#259 

## 📸 스크린샷 (선택)

<img width="2386" alt="스크린샷 2025-03-10 오전 12 53 51" src="https://github.com/user-attachments/assets/127dfaac-b981-4576-ad9c-273a17a7e7a8" />

